### PR TITLE
[update] JFLD link

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ MT-Bench の前身である [vicuna-blog-eval](https://github.com/lm-sys/vicuna-
 <a id="logical-reasoning-benchmark-suites"></a>
 ### 論理推論能力を測定するベンチマーク/データセット
 
-#### [JFLD (Japanese Formal Logic Deduction)](https://www.anlp.jp/proceedings/annual_meeting/2024/pdf_dir/A4-1.pdf) (日立製作所)
+#### [JFLD (Japanese Formal Logic Deduction)](https://aclanthology.org/2024.lrec-main.832/) (日立製作所)
 
 日本語 LLM の演繹推論能力を問うデータセット（同著者らが提案している [FLD (Formal Logic Deduction)](https://github.com/hitachi-nlp/FLD) の日本語版）。LLM が持つ知識と切り分けて評価を行うために、反実仮想的なサンプルから構成されているのが特徴である。
 

--- a/README_en.md
+++ b/README_en.md
@@ -402,7 +402,7 @@ This is the Japanese version of [vicuna-blog-eval](https://github.com/lm-sys/vic
 <a id="logical-reasoning-benchmark-suites"></a>
 ### Benchmarks for measuring logical reasoning capabilities
 
-#### [JFLD (Japanese Formal Logic Deduction)](https://huggingface.co/datasets/hitachi-nlp/JFLD) (Hitachi)
+#### [JFLD (Japanese Formal Logic Deduction)](https://aclanthology.org/2024.lrec-main.832/) (Hitachi)
 
 A dataset for evaluating deductive reasoning capabilities of Japanese LLMs (the Japanese version of the [FLD (Formal Logic Deduction)](https://github.com/hitachi-nlp/FLD) proposed by the same authors). It is characterized by being composed of counterfactual samples to evaluate apart from the knowledge the LLM possesses.
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -404,7 +404,7 @@ Il s'agit de la version japonaise de [vicuna-blog-eval](https://github.com/lm-sy
 <a id="logical-reasoning-benchmark-suites"></a>
 ### Benchmarks pour mesurer les capacités de raisonnement logique
 
-#### [JFLD (Japanese Formal Logic Deduction)](https://huggingface.co/datasets/hitachi-nlp/JFLD) (Hitachi)
+#### [JFLD (Japanese Formal Logic Deduction)](https://aclanthology.org/2024.lrec-main.832/) (Hitachi)
 
 Un dataset pour évaluer les capacités de raisonnement déductif des LLM japonais (la version japonaise de la [FLD (Formal Logic Deduction)](https://github.com/hitachi-nlp/FLD) proposée par les mêmes auteurs). Il se caractérise par le fait qu'il est composé d'exemples contrefactuels pour évaluer indépendamment des connaissances que possède le LLM.
 


### PR DESCRIPTION
ベンチマーク「JFLD」のリンクを、国際学会論文に統一しました。
よろです。