### PR TITLE
add Llama 3.1 Shisa V2 405B model

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@
 
 |    | ベースのLLM  | 学習テキスト | 開発元  | ライセンス / 利用規約 |
 |:---|:---:|:---:|:---:|:---:|
+| [Llama 3.1 Shisa V2 405B](https://shisa.ai/posts/shisa-v2-405b-ja-pr/)<br>([**405b**](https://huggingface.co/shisa-ai/shisa-v2-llama3.1-405b)) | Llama 3.1 (**405b**) | 高品質な日本語データセットでSFT/DPO | Shisa.AI | Llama 3.1 Community License |
 | [AXCXEPT/EZO-Qwen2.5-72B-Instruct](https://huggingface.co/AXCXEPT/EZO-Qwen2.5-72B-Instruct)<br>[AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4](https://huggingface.co/AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4) | Qwen2.5 (**72b**) || Axcxept | Qwen License |
 | [ao-Karasu](https://note.com/lightblue_tech/n/nfda12435b262)<br>([72B](https://huggingface.co/lightblue/ao-karasu-72B)) | Qwen1.5 (**72b**) | ultra-orca-boros-en-ja-v1, OASST1, ShareGPT, 日本語の公開技術ブログ, ニュース記事, QAサイトの回答, 独自のデータセット | Lightblue |  Tongyi Qianwen LICENSE (?)[^12] |
 | [shisa-ai/shisa-v2-llama3.3-70b](https://huggingface.co/shisa-ai/shisa-v2-llama3.3-70b) | Llama 3.3 (**70b**) || Shisa.AI | Llama 3.3 Community License |

--- a/en/README.md
+++ b/en/README.md
@@ -188,6 +188,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 
 |    | Base Model  | Training Data  | Developer  |  License / Terms of Use |
 |:---|:---:|:---:|:---:|:---:|
+| [Llama 3.1 Shisa V2 405B](https://shisa.ai/posts/shisa-v2-405b-ja-pr/)<br>([**405b**](https://huggingface.co/shisa-ai/shisa-v2-llama3.1-405b)) | Llama 3.1 (**405b**) | High-quality Japanese datasets with SFT/DPO | Shisa.AI | Llama 3.1 Community License |
 | [AXCXEPT/EZO-Qwen2.5-72B-Instruct](https://huggingface.co/AXCXEPT/EZO-Qwen2.5-72B-Instruct)<br>[AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4](https://huggingface.co/AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4) | Qwen2.5 (**72b**) || Axcxept | Qwen License |
 | [ao-Karasu](https://note.com/peter_lightblue/n/n483d194d3614)<br>([72B](https://huggingface.co/lightblue/ao-karasu-72B)) | Qwen1.5 (**72b**) | ultra-orca-boros-en-ja-v1, OASST1, ShareGPT, Japanese technical blogs, News stories, QA site answers, undisclosed dataset | Lightblue |  Tongyi Qianwen LICENSE (?)[^12] |
 | [shisa-ai/shisa-v2-llama3.3-70b](https://huggingface.co/shisa-ai/shisa-v2-llama3.3-70b) | Llama 3.3 (**70b**) || Shisa.AI | Llama 3.3 Community License |

--- a/fr/README.md
+++ b/fr/README.md
@@ -188,6 +188,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 
 |    | Base du Model  |  Données d'entraînement  |  Développeur  |  Licence / Conditions d'utilisation  |
 |:---|:---:|:---:|:---:|:---:|
+| [Llama 3.1 Shisa V2 405B](https://shisa.ai/posts/shisa-v2-405b-ja-pr/)<br>([**405b**](https://huggingface.co/shisa-ai/shisa-v2-llama3.1-405b)) | Llama 3.1 (**405b**) | Jeux de données japonais de haute qualité avec SFT/DPO | Shisa.AI | Llama 3.1 Community License |
 | [AXCXEPT/EZO-Qwen2.5-72B-Instruct](https://huggingface.co/AXCXEPT/EZO-Qwen2.5-72B-Instruct)<br>[AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4](https://huggingface.co/AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4) | Qwen2.5 (**72b**) || Axcxept | Qwen License |
 | [ao-Karasu](https://note.com/peter_lightblue/n/n483d194d3614)<br>([72B](https://huggingface.co/lightblue/ao-karasu-72B)) | Qwen1.5 (**72b**) | ultra-orca-boros-en-ja-v1, OASST1, ShareGPT, Japanese technical blogs, News stories, QA site answers, undisclosed dataset | Lightblue |  Tongyi Qianwen LICENSE (?)[^12] |
 | [shisa-ai/shisa-v2-llama3.3-70b](https://huggingface.co/shisa-ai/shisa-v2-llama3.3-70b) | Llama 3.3 (**70b**) || Shisa.AI | Llama 3.3 Community License |


### PR DESCRIPTION
## Summary
- Add Llama 3.1 Shisa V2 405B model to post-training only section across all language versions
- Based on Shisa AI blog post about achieving GPT-4 level Japanese performance

## Changes
- **Model**: shisa-ai/shisa-v2-llama3.1-405b (405B parameters)
- **Section**: Post-training only models (事後学習のみ行ったモデル)
- **Training**: High-quality Japanese datasets with SFT/DPO
- **Performance**: Exceeds METI benchmark targets, surpasses GPT-4 in Japanese
- **License**: Llama 3.1 Community License
- Updated Japanese, English, and French versions consistently

## Test plan
- [x] Verify model information is accurate based on the blog post and Hugging Face page
- [x] Confirm proper placement in post-training only section (not continual pre-training)
- [x] Check parameter size ordering (405B at top of section)
- [x] Ensure correct license information (Llama 3.1 Community License)
- [x] Verify all three language versions are updated consistently

Closes #506

🤖 Generated with [Claude Code](https://claude.ai/code)