### PR TITLE
Add Japanese MULAN music-language model (#522)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,12 +136,14 @@ When adding new models to the documentation:
 #### Pre-Addition Checklist
 1. **Verify model information** from official sources (Hugging Face, research papers, official announcements)
 2. **Identify correct domain classification** - don't assume similar domains are the same (薬学 ≠ 医療)
+   - **New model types**: If the model doesn't fit existing categories (e.g., music-language models vs speech-language models), create new sections following the established hierarchy
 3. **Check existing model formats** in the target section for:
    - Architecture naming conventions (e.g., "BERT (base, large)" vs "BERT (large)")
    - License format standards
    - HuggingFace availability symbols (◯, △, ？)
 4. **Determine insertion position** based on parameter size and domain grouping
 5. **Plan multilingual updates** - prepare translations for all three versions
+6. **Check for related research papers** - if the model is based on research, add the original paper to `parts/references_model.md` in chronological order
 
 #### Architecture Format Standards
 - Multiple sizes: Use format like "BERT (base, large)" to indicate both variants exist
@@ -153,6 +155,12 @@ When adding new models to the documentation:
 - Models should be grouped by domain first, then ordered by parameter size within each domain
 - Specialized domains (薬学, 医療, 金融, etc.) are separate categories
 - When adding to a new domain, place it in logical order relative to existing domains
+
+#### Research Paper References
+- When adding models based on research papers, always add the original paper to `parts/references_model.md`
+- Papers should be ordered chronologically by submission/publication date
+- Include venue information (conference/journal) if published, or "-" if arXiv-only
+- Verify publication venue and dates from authoritative sources (not just arXiv)
 
 ## Contributing Notes
 

--- a/README.md
+++ b/README.md
@@ -486,6 +486,16 @@
 | [Reazon wav2vec 2.0](https://research.reazon.jp/blog/2024-10-21-Wav2Vec2-base-release.html)<br>([base](https://huggingface.co/reazon-research/japanese-wav2vec2-base), [large](https://huggingface.co/reazon-research/japanese-wav2vec2-large)) | wav2vec 2.0 | ReazonSpeech | レアゾン・ホールディングス | Apache 2.0 |
 | [rinna wav2vec 2.0](https://rinna.co.jp/news/2024/03/20240307.html)<br>([base](https://huggingface.co/rinna/japanese-wav2vec2-base)) | wav2vec 2.0 | ReazonSpeech | rinna | Apache 2.0 |
 
+<a id="music"></a>
+## 音楽言語モデル (Music-Language Models)
+
+<a id="music-text-conversion"></a>
+### 音楽-テキスト間変換
+
+|    |  アーキテクチャ  |  学習コーパス  |  開発元  | ライセンス |
+|:---|:---:|:---:|:---:|:---:|
+| [Japanese MULAN](https://huggingface.co/line-corporation/japanese-mulan-base)<br>([japanese-mulan-base](https://huggingface.co/line-corporation/japanese-mulan-base)) | MULAN (AST + GLuCoSE) | 〜20k 社内音楽-テキストペア | LINEヤフー | Apache 2.0 |
+
 <a id="benchmark-suites"></a>
 ## 日本語LLM評価ベンチマーク/データセットまとめ
 

--- a/en/README.md
+++ b/en/README.md
@@ -485,6 +485,16 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 | [Reazon wav2vec 2.0](https://research.reazon.jp/blog/2024-10-21-Wav2Vec2-base-release.html)<br>([base](https://huggingface.co/reazon-research/japanese-wav2vec2-base), [large](https://huggingface.co/reazon-research/japanese-wav2vec2-large)) | wav2vec 2.0 | ReazonSpeech | Reazon Holdings | Apache 2.0 |
 | [rinna wav2vec 2.0](https://rinna.co.jp/news/2024/03/20240307.html)<br>([base](https://huggingface.co/rinna/japanese-wav2vec2-base)) | wav2vec 2.0 | ReazonSpeech | rinna | Apache 2.0 |
 
+<a id="music"></a>
+## Music-Language Models
+
+<a id="music-text-conversion"></a>
+### Music-Text Conversion
+
+|    |  Architecture  |  Training Data  |  Developer  | License |
+|:---|:---:|:---:|:---:|:---:|
+| [Japanese MULAN](https://huggingface.co/line-corporation/japanese-mulan-base)<br>([japanese-mulan-base](https://huggingface.co/line-corporation/japanese-mulan-base)) | MULAN (AST + GLuCoSE) | ~20k internal music-text pairs | LY Corporation | Apache 2.0 |
+
 <a id="benchmark-suites"></a>
 ## Evaluation Benchmarks for Japanese LLMs
 

--- a/fr/README.md
+++ b/fr/README.md
@@ -485,6 +485,16 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 | [Reazon wav2vec 2.0](https://research.reazon.jp/blog/2024-10-21-Wav2Vec2-base-release.html)<br>([base](https://huggingface.co/reazon-research/japanese-wav2vec2-base), [large](https://huggingface.co/reazon-research/japanese-wav2vec2-large)) | wav2vec 2.0 | ReazonSpeech | Reazon Holdings | Apache 2.0 |
 | [rinna wav2vec 2.0](https://rinna.co.jp/news/2024/03/20240307.html)<br>([base](https://huggingface.co/rinna/japanese-wav2vec2-base)) | wav2vec 2.0 | ReazonSpeech | rinna | Apache 2.0 |
 
+<a id="music"></a>
+## Modèles Musique-Langage
+
+<a id="music-text-conversion"></a>
+### Conversion Musique-Texte
+
+|    |  Architecture  |  Données d'entraînement  |  Développeur  | Licence |
+|:---|:---:|:---:|:---:|:---:|
+| [Japanese MULAN](https://huggingface.co/line-corporation/japanese-mulan-base)<br>([japanese-mulan-base](https://huggingface.co/line-corporation/japanese-mulan-base)) | MULAN (AST + GLuCoSE) | ~20k paires musique-texte internes | LY Corporation | Apache 2.0 |
+
 <a id="benchmark-suites"></a>
 ## Standard d'évaluation pour les LLM en japonais
 

--- a/parts/references_model.md
+++ b/parts/references_model.md
@@ -35,6 +35,7 @@
 | DiffCSE | 2022.04.21 | NAACL 2022 | [DiffCSE: Difference-based Contrastive Learning for Sentence Embeddings](https://aclanthology.org/2022.naacl-main.311/) |
 | GIT | 2022.05.27 | TMLR 2022 | [GIT: A Generative Image-to-text Transformer for Vision and Language](https://arxiv.org/abs/2205.14100) |
 | CogVideo | 2022.05.29 | ICLR 2023 | [CogVideo: Large-scale Pretraining for Text-to-Video Generation via Transformers](https://arxiv.org/abs/2205.15868) |
+| MuLan | 2022.08.26 | ISMIR 2022 | [MuLan: A Joint Embedding of Music Audio and Natural Language](https://arxiv.org/abs/2208.12415) |
 | Whisper | 2022.12.06 | ICML 2023 | [Robust Speech Recognition via Large-Scale Weak Supervision](https://arxiv.org/abs/2212.04356) |
 | BLIP-2 | 2023.01.30 | ICML 2023 | [BLIP-2: Bootstrapping Language-Image Pre-training with Frozen Image Encoders and Large Language Models](https://arxiv.org/abs/2301.12597) |
 | ControlNet | 2023.02.10 | ICCV 2023 | [Adding Conditional Control to Text-to-Image Diffusion Models](https://arxiv.org/abs/2302.05543) |


### PR DESCRIPTION
## Summary
- Add japanese-mulan-base model to documentation with new "Music-Language Models" section
- Add MuLan research paper reference to chronological list
- Update documentation guidelines for new model types

## Changes Made
- **New Section**: Created "音楽言語モデル (Music-Language Models)" section for models that handle music-text conversion
- **Model Added**: japanese-mulan-base (219M parameters, MULAN architecture, LY Corporation, Apache 2.0)
- **Research Reference**: Added MuLan paper (ISMIR 2022) to `parts/references_model.md` in chronological order
- **Documentation Guidelines**: Enhanced CLAUDE.md with guidance for new model categories and research paper references
- **Multilingual Support**: Consistent additions across Japanese, English, and French versions

## Test plan
- [x] Verify model information from official sources (HuggingFace, LY Corp blog)
- [x] Ensure consistent formatting across all three language versions
- [x] Confirm research paper details and chronological placement
- [x] Validate new section structure follows existing patterns

🤖 Generated with [Claude Code](https://claude.ai/code)