### PR TITLE
Add Sarashina-Embedding-v2-1B to embedding models

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@
 |:---|:---:|:---:|:---:|
 | [Ruri-v3](https://huggingface.co/collections/cl-nagoya/ruri-v3-67f382536e80902074ec6252)<br>([v3-30m](https://huggingface.co/cl-nagoya/ruri-v3-30m), [v3-70m](https://huggingface.co/cl-nagoya/ruri-v3-70m), [v3-130m](https://huggingface.co/cl-nagoya/ruri-v3-130m), [v3-310m](https://huggingface.co/cl-nagoya/ruri-v3-310m)) | 8,192 | 名大 笹野研 | Apache 2.0 |
 | [PLaMo-Embedding-1B](https://tech.preferred.jp/ja/blog/plamo-embedding-1b/)<br>([1b](https://huggingface.co/pfnet/plamo-embedding-1b)) | 4,096 | Preferred Networks | Apache 2.0 |
+| [Sarashina-Embedding-v2](https://www.sbintuitions.co.jp/blog/entry/2025/08/20/160139)<br>([v2-1b](https://huggingface.co/sbintuitions/sarashina-embedding-v2-1b)) | 8,192 | SB Intuitions | Sarashina Model NonCommercial License |
 | [sbintuitions/sarashina-embedding-v1-1b](https://huggingface.co/sbintuitions/sarashina-embedding-v1-1b) | 8,192 | SB Intuitions | Sarashina Model NonCommercial License |
 | [AMBER](https://retrieva.jp/news/ENCTPk6I)<br>([base](https://huggingface.co/retrieva-jp/amber-base), [large](https://huggingface.co/retrieva-jp/amber-large)) | 512 | レトリバ | Apache 2.0 |
 | [RoSEtta](https://prtimes.jp/main/html/rd/p/000000169.000022705.html)<br>([base-ja](https://huggingface.co/pkshatech/RoSEtta-base-ja)) | 1,024 | PKSHA Technology | Apache 2.0 |

--- a/en/README.md
+++ b/en/README.md
@@ -352,6 +352,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 |:---|:---:|:---:|:---:|
 | [Ruri-v3](https://huggingface.co/collections/cl-nagoya/ruri-v3-67f382536e80902074ec6252)<br>([v3-30m](https://huggingface.co/cl-nagoya/ruri-v3-30m), [v3-70m](https://huggingface.co/cl-nagoya/ruri-v3-70m), [v3-130m](https://huggingface.co/cl-nagoya/ruri-v3-130m), [v3-310m](https://huggingface.co/cl-nagoya/ruri-v3-310m)) | 8,192 | Nagoya University Sasano Group | Apache 2.0 |
 | [PLaMo-Embedding-1B](https://tech.preferred.jp/ja/blog/plamo-embedding-1b/)<br>([1b](https://huggingface.co/pfnet/plamo-embedding-1b)) | 4,096 | Preferred Networks | Apache 2.0 |
+| [Sarashina-Embedding-v2](https://www.sbintuitions.co.jp/blog/entry/2025/08/20/160139)<br>([v2-1b](https://huggingface.co/sbintuitions/sarashina-embedding-v2-1b)) | 8,192 | SB Intuitions | Sarashina Model NonCommercial License |
 | [sbintuitions/sarashina-embedding-v1-1b](https://huggingface.co/sbintuitions/sarashina-embedding-v1-1b) | 8,192 | SB Intuitions | Sarashina Model NonCommercial License |
 | [AMBER](https://retrieva.jp/news/ENCTPk6I)<br>([base](https://huggingface.co/retrieva-jp/amber-base), [large](https://huggingface.co/retrieva-jp/amber-large)) | 512 | Retrieva | Apache 2.0 |
 | [RoSEtta](https://prtimes.jp/main/html/rd/p/000000169.000022705.html)<br>([base-ja](https://huggingface.co/pkshatech/RoSEtta-base-ja)) | 1,024 | PKSHA Technology | Apache 2.0 |

--- a/fr/README.md
+++ b/fr/README.md
@@ -352,6 +352,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 |:---|:---:|:---:|:---:|
 | [Ruri-v3](https://huggingface.co/collections/cl-nagoya/ruri-v3-67f382536e80902074ec6252)<br>([v3-30m](https://huggingface.co/cl-nagoya/ruri-v3-30m), [v3-70m](https://huggingface.co/cl-nagoya/ruri-v3-70m), [v3-130m](https://huggingface.co/cl-nagoya/ruri-v3-130m), [v3-310m](https://huggingface.co/cl-nagoya/ruri-v3-310m)) | 8,192 | Nagoya University Sasano Group | Apache 2.0 |
 | [PLaMo-Embedding-1B](https://tech.preferred.jp/ja/blog/plamo-embedding-1b/)<br>([1b](https://huggingface.co/pfnet/plamo-embedding-1b)) | 4,096 | Preferred Networks | Apache 2.0 |
+| [Sarashina-Embedding-v2](https://www.sbintuitions.co.jp/blog/entry/2025/08/20/160139)<br>([v2-1b](https://huggingface.co/sbintuitions/sarashina-embedding-v2-1b)) | 8,192 | SB Intuitions | Sarashina Model NonCommercial License |
 | [sbintuitions/sarashina-embedding-v1-1b](https://huggingface.co/sbintuitions/sarashina-embedding-v1-1b) | 8,192 | SB Intuitions | Sarashina Model NonCommercial License |
 | [AMBER](https://retrieva.jp/news/ENCTPk6I)<br>([base](https://huggingface.co/retrieva-jp/amber-base), [large](https://huggingface.co/retrieva-jp/amber-large)) | 512 | Retrieva | Apache 2.0 |
 | [RoSEtta](https://prtimes.jp/main/html/rd/p/000000169.000022705.html)<br>([base-ja](https://huggingface.co/pkshatech/RoSEtta-base-ja)) | 1,024 | PKSHA Technology | Apache 2.0 |


### PR DESCRIPTION
## Summary
- Added Sarashina-Embedding-v2 (1B) to the Single-representation bi-encoders section in all three language versions

## Model Details
- **Model**: Sarashina-Embedding-v2-1B (1B parameters)
- **Base Model**: Sarashina2.2-1B
- **Max Context Length**: 8,192 tokens
- **Output Dimensions**: 1,792
- **Architecture**: Sentence Transformer based on LLM with pooling layer
- **License**: Sarashina Model NonCommercial License (commercial use requires contacting developer)
- **Developer**: SB Intuitions

## Training Methodology
Three-stage training approach:
1. **Stage 1 - Contrastive Learning**: Weakly-supervised learning with web-crawled data and open datasets
2. **Stage 2 - Supervised Fine-Tuning**: Higher-quality triplet data (query-positive-negative) with synthetic data generation and hard negative mining
3. **Stage 3 - Model Merging**: Linear merging of two best-performing models from Stage 2

## Key Features
- Task-adaptive embeddings with instruction support
- Format: `task: {instruction}\nquery: {text}` for queries, `text: {document}` for documents
- Supports semantic similarity, search, clustering, and classification tasks

## Performance
- **JMTEB Benchmark**: 76.38 average score (state-of-the-art)
  - Retrieval: 76.48
  - STS: 84.22
  - Reranking: 86.28

## Links
- **HuggingFace**: https://huggingface.co/sbintuitions/sarashina-embedding-v2-1b
- **Technical Article**: https://www.sbintuitions.co.jp/blog/entry/2025/08/20/160139

## Changes
- Updated README.md (Japanese) at line 355
- Updated en/README.md (English) at line 355
- Updated fr/README.md (French) at line 355

All three versions maintain consistent model placement in the Single-representation bi-encoders section, positioned after PLaMo-Embedding-1B and before sarashina-embedding-v1-1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)