### PR TITLE
Exclude Hugging Face URLs from link checker

### DIFF
--- a/.404-links.yml
+++ b/.404-links.yml
@@ -5,6 +5,7 @@ ignore:
     - https://arxiv.org/*
     - https://developers-jp.googleblog.com/2024/10/gemma-2-for-japan.html
     - https://gitlab.llm-jp.nii.ac.jp/datasets/*
+    - https://huggingface.co/*
     - https://llm-jp.nii.ac.jp/*
     - https://ojs.aaai.org/*
     - https://scholar.google.co.jp/*
@@ -12,5 +13,3 @@ ignore:
     - https://www.anlp.jp/*
     - https://www.informatix.co.jp/pr-roberta/
     - https://www.recruit.co.jp/newsroom/pressrelease/2021/0826_9293.html
-delay:
-  'https://huggingface.co': 1000


### PR DESCRIPTION
## Summary
- Exclude `huggingface.co` domain from 404 link checker to avoid 429 (Too Many Requests) errors in CI
- Initially tried adding a delay between requests, but it was insufficient to prevent rate limiting

## Changes
- Updated `.404-links.yml` to add `https://huggingface.co/*` to the ignore list

## Test Plan
- This PR will trigger the link checker CI workflow
- Verify that the link checker completes successfully without checking Hugging Face URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)