### PR TITLE
Add JFBench: 日本語LLMの指示追従能力ベンチマーク

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,11 +595,12 @@
 | [JMultiPL-E](https://huggingface.co/datasets/tohoku-nlp/JMultiPL-E) | OpenAI HumanEval をベースに 17 のプログラミング言語（C++, C#, Go, Java, JavaScript, PHP, Ruby, Rust, Scala, Swift, TypeScript など）でコード生成能力を評価するデータセット。多言語でのコード理解とコード生成の性能を測定する。| 東北大 自然言語処理研究グループ |
 
 <a id="controllabilitiy-benchmark-suites"></a>
-### 制約付きの生成能力を測定するベンチマーク/データセット
+### 指示追従能力を測定するベンチマーク/データセット
 
 |   | 説明 | 開発元 |
 |:---|:---|:---:|
 | [LCTG Bench](https://github.com/CyberAgentAILab/LCTG-Bench) | 日本語 LLM の制御性ベンチマーク。出力のフォーマット、文字数、キーワード、NGワードの 4 つの観点から、LLM が制約を守って出力を行えているかを評価する。生成されたテキストの品質も合わせて評価する。 | サイバーエージェント |
+| [JFBench](https://github.com/pfnet-research/jfbench) | 日本語 LLM の指示追従能力を評価するベンチマーク。IFBench を翻訳した 6 グループに加え、日本語特有の制約（敬体・常体、ひらがな・カタカナ・漢字の混在、数値表記など）10 グループを新たに作成。16 の制約グループ・174 の制約タイプを持ち、制約数 1/2/4/8 の組み合わせで計 1,600 サンプルを評価する。 | Preferred Networks |
 
 <a id="embeddings-benchmark-suites"></a>
 ### 埋め込みモデルのベンチマーク/データセット

--- a/en/README.md
+++ b/en/README.md
@@ -595,11 +595,12 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 | [JMultiPL-E](https://huggingface.co/datasets/tohoku-nlp/JMultiPL-E) | A dataset for evaluating code generation capabilities across 17 programming languages (C++, C#, Go, Java, JavaScript, PHP, Ruby, Rust, Scala, Swift, TypeScript, etc.) based on OpenAI HumanEval. Measures multilingual code understanding and generation performance. | Tohoku University Natural Language Processing Group |
 
 <a id="controllabilitiy-benchmark-suites"></a>
-### Benchmarks on controlled text generation
+### Benchmarks on instruction-following ability
 
 |   | Description | Developer |
 |:---|:---|:---:|
 | [LCTG Bench](https://github.com/CyberAgentAILab/LCTG-Bench) | A benchmark for the controllability of Japanese LLMs. It evaluates whether LLMs can adhere to constraints in four aspects: output format, character count, keywords, and forbidden words. The quality of the generated text is also evaluated. | CyberAgent |
+| [JFBench](https://github.com/pfnet-research/jfbench) | A benchmark for evaluating the instruction-following ability of Japanese LLMs. In addition to 6 constraint groups translated from IFBench, 10 new groups specific to Japanese were created (e.g., polite/plain style, mixed hiragana/katakana/kanji, numerical notation). It has 16 constraint groups and 174 constraint types, evaluating a total of 1,600 samples with constraint counts of 1/2/4/8. | Preferred Networks |
 
 <a id="embeddings-benchmark-suites"></a>
 ### Benchmarks for embedding models

--- a/fr/README.md
+++ b/fr/README.md
@@ -595,11 +595,12 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 | [JMultiPL-E](https://huggingface.co/datasets/tohoku-nlp/JMultiPL-E) | Un dataset pour évaluer les capacités de génération de code dans 17 langages de programmation (C++, C#, Go, Java, JavaScript, PHP, Ruby, Rust, Scala, Swift, TypeScript, etc.) basé sur OpenAI HumanEval. Mesure les performances de compréhension et de génération de code multilingue. | Université de Tohoku - Groupe de Recherche en Traitement du Langage Naturel |
 
 <a id="controllabilitiy-benchmark-suites"></a>
-### Benchmarks pour la génération de texte contrôlée
+### Benchmarks pour la capacité de suivi d'instructions
 
 |   | Description | Développeur |
 |:---|:---|:---:|
 | [LCTG Bench](https://github.com/CyberAgentAILab/LCTG-Bench) | Un benchmark pour la contrôlabilité des LLM japonais. Il évalue si les LLM peuvent adhérer à des contraintes sur quatre aspects : le format de sortie, le nombre de caractères, les mots-clés et les mots interdits. La qualité du texte généré est également évaluée. | CyberAgent |
+| [JFBench](https://github.com/pfnet-research/jfbench) | Un benchmark pour évaluer la capacité de suivi d'instructions des LLM japonais. En plus de 6 groupes de contraintes traduits d'IFBench, 10 nouveaux groupes spécifiques au japonais ont été créés (par ex., style poli/neutre, mélange hiragana/katakana/kanji, notation numérique). Il comporte 16 groupes de contraintes et 174 types de contraintes, évaluant un total de 1 600 échantillons avec des nombres de contraintes de 1/2/4/8. | Preferred Networks |
 
 <a id="embeddings-benchmark-suites"></a>
 ### Benchmarks pour modèles d'embeddings


### PR DESCRIPTION
## Summary
- Add [JFBench](https://github.com/pfnet-research/jfbench) (Preferred Networks) to the instruction-following benchmark section
- Rename section from "制約付きの生成能力を測定するベンチマーク" to "指示追従能力を測定するベンチマーク" to better encompass both LCTG Bench and JFBench under the broader concept of instruction-following ability
- Updated all 3 language versions (JA, EN, FR) with consistent content and positioning

## Test plan
- [x] `yarn docs:build` passes successfully
- [x] All 3 language files updated in the same position
- [x] Anchor ID `controllabilitiy-benchmark-suites` preserved for link compatibility

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)