### PR TITLE
Add MedRECT: 臨床記録の誤り検出・訂正ベンチマーク

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@
 | [YakugakuQA](https://github.com/EQUES-Inc/pharma-LLM-eval) | 薬剤師国家試験をベースとした日本語製薬分野の知識を問う評価データセット。事実に基づく薬学知識を測定する。 | EQUES Inc. |
 | [NayoseQA](https://github.com/EQUES-Inc/pharma-LLM-eval) | 日本語製薬分野での多言語間用語対応・正規化能力を評価するデータセット。同義語や専門用語の理解度を測定する。 | EQUES Inc. |
 | [SogoCheck](https://github.com/EQUES-Inc/pharma-LLM-eval) | 対となる文章間の一貫性推論を評価する新しいタスク。GPT-4oでも性能が低い高難度の推論タスク。 | EQUES Inc. |
+| [MedRECT](https://github.com/pfnet-research/medrect) | 臨床記録における医学的誤りの検出・訂正能力を評価するベンチマーク。誤り検出、誤り文特定、誤り訂正の 3 段階のタスクから構成される。日本語版（663 サンプル）と英語版（458 サンプル）があり、日本語版は医師国家試験をベースに構築されている。 | Preferred Networks |
 | [karakuri-bench](https://huggingface.co/datasets/karakuri-ai/karakuri-bench-v0.1) | 日本語 LLM のカスタマーサポートにおける性能を測定するためのデータセット。 | カラクリ |
 
 <a id="factuality-safety-benchmark-suites"></a>

--- a/en/README.md
+++ b/en/README.md
@@ -574,6 +574,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 | [YakugakuQA](https://github.com/EQUES-Inc/pharma-LLM-eval) | A Japanese pharmaceutical domain evaluation dataset based on national pharmacist licensing exams. Tests factual pharmaceutical knowledge. | EQUES Inc. |
 | [NayoseQA](https://github.com/EQUES-Inc/pharma-LLM-eval) | A Japanese pharmaceutical domain evaluation dataset for cross-lingual terminology normalization. Tests understanding of synonyms and technical terms. | EQUES Inc. |
 | [SogoCheck](https://github.com/EQUES-Inc/pharma-LLM-eval) | A novel task designed to assess consistency reasoning between paired statements. A challenging reasoning task where even GPT-4o performs poorly. | EQUES Inc. |
+| [MedRECT](https://github.com/pfnet-research/medrect) | A benchmark for evaluating the ability to detect and correct medical errors in clinical records. It consists of three tasks: error detection, error sentence identification, and error correction. It includes a Japanese version (663 samples) and an English version (458 samples), with the Japanese version constructed based on the Japanese Medical Licensing Examination. | Preferred Networks |
 | [karakuri-bench](https://huggingface.co/datasets/karakuri-ai/karakuri-bench-v0.1) | A dataset for measuring performance of Japanese LLMs in customer support. | KARAKURI |
 
 <a id="factuality-safety-benchmark-suites"></a>

--- a/fr/README.md
+++ b/fr/README.md
@@ -574,6 +574,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 | [YakugakuQA](https://github.com/EQUES-Inc/pharma-LLM-eval) | Un jeu de données d'évaluation du domaine pharmaceutique japonais basé sur les examens nationaux de licence de pharmacien. Teste les connaissances pharmaceutiques factuelles. | EQUES Inc. |
 | [NayoseQA](https://github.com/EQUES-Inc/pharma-LLM-eval) | Un jeu de données d'évaluation du domaine pharmaceutique japonais pour la normalisation terminologique multilingue. Teste la compréhension des synonymes et des termes techniques. | EQUES Inc. |
 | [SogoCheck](https://github.com/EQUES-Inc/pharma-LLM-eval) | Une nouvelle tâche conçue pour évaluer le raisonnement de cohérence entre des déclarations appariées. Une tâche de raisonnement difficile où même GPT-4o performe mal. | EQUES Inc. |
+| [MedRECT](https://github.com/pfnet-research/medrect) | Un benchmark pour évaluer la capacité à détecter et corriger les erreurs médicales dans les dossiers cliniques. Il se compose de trois tâches : détection d'erreurs, identification de la phrase erronée et correction d'erreurs. Il comprend une version japonaise (663 échantillons) et une version anglaise (458 échantillons), la version japonaise étant construite à partir de l'examen national de médecine japonais. | Preferred Networks |
 | [karakuri-bench](https://huggingface.co/datasets/karakuri-ai/karakuri-bench-v0.1) | Un ensemble de données pour mesurer la performance des LLM japonais dans le support client. | KARAKURI |
 
 <a id="factuality-safety-benchmark-suites"></a>


### PR DESCRIPTION
## Summary
- Add [MedRECT](https://github.com/pfnet-research/medrect) (Preferred Networks) to the domain-specific benchmark section
- A benchmark for evaluating the ability to detect and correct medical errors in clinical records, consisting of 3 tasks: error detection, error sentence identification, and error correction
- Japanese version (663 samples, based on Japanese Medical Licensing Examination) and English version (458 samples)
- Updated all 3 language versions (JA, EN, FR) with consistent content and positioning

## Test plan
- [x] `yarn docs:build` passes successfully
- [x] All 3 language files updated in the same position

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)