### PR TITLE
Add Qwen3.5-FT-Japanese-CoT: 日本語CoT SFTモデル

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ Models are classified into sections based on training approach. **Evidence is re
 - **Multiple sizes**: Combine into single row: `([**7b**](url1), [**13b**](url2))`
 - **License format**: Use official names with consistent capitalization
 - **Release year bolding**: The latest/newest release year (e.g., the current year) should be **bolded** in the table. When the year is no longer the newest, the bold is removed (see commit history for precedent).
+- **Developer column for individuals**: When the developer is an individual (not a company/university/research lab), use the format `個人 (name)` (JA) / `Individual (name)` (EN) / `Individuel (name)` (FR). Do NOT write the HuggingFace username alone.
 
 ### Multilingual Consistency
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@
 | [izumi-lab/llama-7b-japanese-lora-v0-5ep](https://huggingface.co/izumi-lab/llama-7b-japanese-lora-v0-5ep) | Llama (**7b**) || 東大 和泉研 |  ？  |
 | [lightblue/jod](https://huggingface.co/lightblue/jod) | Mistral-7B-SlimOrca (**7b**) || Lightblue | Apache 2.0 |
 | [NTQAI/chatntq-7b-jpntuned](https://huggingface.co/NTQAI/chatntq-7b-jpntuned) | RWKV-4 World (**7b**) || NTQ Solution |  ？  |
+| [Qwen3.5-FT-Japanese-CoT-4B](https://huggingface.co/Aname-Tommy/Qwen3.5-FT-Japanese-CoT-4B) | Qwen3.5 (**4b**) | 不明 | 個人 (Aname-Tommy) | MIT |
 | [Borea](https://prtimes.jp/main/html/rd/p/000000008.000129878.html)<br>([Jp](https://huggingface.co/AXCXEPT/Borea-Phi-3.5-mini-Instruct-Jp), [Common](https://huggingface.co/AXCXEPT/Borea-Phi-3.5-mini-Instruct-Common), [Coding](https://huggingface.co/AXCXEPT/Borea-Phi-3.5-mini-Instruct-Coding)) | Phi-3.5 (**3.8b**) | | Axcxept | MIT |
 | [Shisa V2.1 3B](https://shisa.ai/posts/shisa-v2.1-ja-pr/)<br>([**3b**](https://huggingface.co/shisa-ai/shisa-v2.1-llama3.2-3b)) | Llama 3.2 (**3b**) | SFT/DPO/強化学習/モデルマージを組み合わせた学習 | Shisa.AI | Llama 3.2 Community License |
 | [AXCXEPT/EZO-Llama-3.2-3B-Instruct-dpoE](https://huggingface.co/AXCXEPT/EZO-Llama-3.2-3B-Instruct-dpoE) | Llama 3.2 (**3b**) || Axcxept | Llama 3.2 Community License |
@@ -257,6 +258,7 @@
 | [AXCXEPT/EZO-Common-T2-2B-gemma-2-it](https://huggingface.co/AXCXEPT/EZO-Common-T2-2B-gemma-2-it) | Gemma 2 (**2b**) || Axcxept | Gemma Terms of Use |
 | [Shisa V2.1 1.2B](https://shisa.ai/posts/shisa-v2.1-ja-pr/)<br>([**1.2b**](https://huggingface.co/shisa-ai/shisa-v2.1-lfm2-1.2b)) | LFM2 (**1.2b**) | SFT/DPO/強化学習/モデルマージを組み合わせた学習 | Shisa.AI | LFM Open License v1.0 |
 | [LFM2.5-1.2B-JP](https://www.liquid.ai/blog/introducing-lfm2-5-the-next-generation-of-on-device-ai)<br>([1.2B-JP](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP)) | LFM2.5 (**1.2b**) | 不明 | Liquid AI | LFM Open License v1.0 |
+| [Qwen3.5-FT-Japanese-CoT-0.8B](https://huggingface.co/Aname-Tommy/Qwen3.5-FT-Japanese-CoT-0.8B) | Qwen3.5 (**0.8b**) | 不明 | 個人 (Aname-Tommy) | MIT |
 
 <a id="generative-instruction-only-domain-specific"></a>
 #### ドメイン特化型

--- a/en/README.md
+++ b/en/README.md
@@ -249,6 +249,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 | [izumi-lab/llama-7b-japanese-lora-v0-5ep](https://huggingface.co/izumi-lab/llama-7b-japanese-lora-v0-5ep) | Llama (**7b**) || University of Tokyo Izumi Lab |  ？  |
 | [lightblue/jod](https://huggingface.co/lightblue/jod) | Mistral-7B-SlimOrca (**7b**) || Lightblue | Apache 2.0 |
 | [NTQAI/chatntq-7b-jpntuned](https://huggingface.co/NTQAI/chatntq-7b-jpntuned) | RWKV-4 World (**7b**)|| NTQ Solution |  ？  |
+| [Qwen3.5-FT-Japanese-CoT-4B](https://huggingface.co/Aname-Tommy/Qwen3.5-FT-Japanese-CoT-4B) | Qwen3.5 (**4b**) | Undisclosed | Individual (Aname-Tommy) | MIT |
 | [Borea](https://prtimes.jp/main/html/rd/p/000000008.000129878.html)<br>([Jp](https://huggingface.co/AXCXEPT/Borea-Phi-3.5-mini-Instruct-Jp), [Common](https://huggingface.co/AXCXEPT/Borea-Phi-3.5-mini-Instruct-Common), [Coding](https://huggingface.co/AXCXEPT/Borea-Phi-3.5-mini-Instruct-Coding)) | Phi-3.5 (**3.8b**) | | Axcxept | MIT |
 | [Shisa V2.1 3B](https://shisa.ai/posts/shisa-v2.1/)<br>([**3b**](https://huggingface.co/shisa-ai/shisa-v2.1-llama3.2-3b)) | Llama 3.2 (**3b**) | Combined SFT/DPO/RL/Model merging | Shisa.AI | Llama 3.2 Community License |
 | [AXCXEPT/EZO-Llama-3.2-3B-Instruct-dpoE](https://huggingface.co/AXCXEPT/EZO-Llama-3.2-3B-Instruct-dpoE) | Llama 3.2 (**3b**) || Axcxept | Llama 3.2 Community License |
@@ -257,6 +258,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 | [AXCXEPT/EZO-Common-T2-2B-gemma-2-it](https://huggingface.co/AXCXEPT/EZO-Common-T2-2B-gemma-2-it) | Gemma 2 (**2b**) || Axcxept | Gemma Terms of Use |
 | [Shisa V2.1 1.2B](https://shisa.ai/posts/shisa-v2.1/)<br>([**1.2b**](https://huggingface.co/shisa-ai/shisa-v2.1-lfm2-1.2b)) | LFM2 (**1.2b**) | Combined SFT/DPO/RL/Model merging | Shisa.AI | LFM Open License v1.0 |
 | [LFM2.5-1.2B-JP](https://www.liquid.ai/blog/introducing-lfm2-5-the-next-generation-of-on-device-ai)<br>([1.2B-JP](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP)) | LFM2.5 (**1.2b**) | Undisclosed | Liquid AI | LFM Open License v1.0 |
+| [Qwen3.5-FT-Japanese-CoT-0.8B](https://huggingface.co/Aname-Tommy/Qwen3.5-FT-Japanese-CoT-0.8B) | Qwen3.5 (**0.8b**) | Undisclosed | Individual (Aname-Tommy) | MIT |
 
 <a id="generative-instruction-only-domain-specific"></a>
 #### Domain specific

--- a/fr/README.md
+++ b/fr/README.md
@@ -249,6 +249,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 | [izumi-lab/llama-7b-japanese-lora-v0-5ep](https://huggingface.co/izumi-lab/llama-7b-japanese-lora-v0-5ep) | Llama (**7b**) || Université de Tokyo Izumi Lab |  ？  |
 | [lightblue/jod](https://huggingface.co/lightblue/jod) | Mistral-7B-SlimOrca (**7b**) || Lightblue | Apache 2.0 |
 | [NTQAI/chatntq-7b-jpntuned](https://huggingface.co/NTQAI/chatntq-7b-jpntuned) | RWKV-4 World (**7b**)|| NTQ Solution |  ？  |
+| [Qwen3.5-FT-Japanese-CoT-4B](https://huggingface.co/Aname-Tommy/Qwen3.5-FT-Japanese-CoT-4B) | Qwen3.5 (**4b**) | Non divulgué | Individuel (Aname-Tommy) | MIT |
 | [Borea](https://prtimes.jp/main/html/rd/p/000000008.000129878.html)<br>([Jp](https://huggingface.co/AXCXEPT/Borea-Phi-3.5-mini-Instruct-Jp), [Common](https://huggingface.co/AXCXEPT/Borea-Phi-3.5-mini-Instruct-Common), [Coding](https://huggingface.co/AXCXEPT/Borea-Phi-3.5-mini-Instruct-Coding)) | Phi-3.5 (**3.8b**) | | Axcxept | MIT |
 | [Shisa V2.1 3B](https://shisa.ai/posts/shisa-v2.1/)<br>([**3b**](https://huggingface.co/shisa-ai/shisa-v2.1-llama3.2-3b)) | Llama 3.2 (**3b**) | Combinaison de SFT/DPO/RL/fusion de modèles | Shisa.AI | Llama 3.2 Community License |
 | [AXCXEPT/EZO-Llama-3.2-3B-Instruct-dpoE](https://huggingface.co/AXCXEPT/EZO-Llama-3.2-3B-Instruct-dpoE) | Llama 3.2 (**3b**) || Axcxept | Llama 3.2 Community License |
@@ -257,6 +258,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 | [AXCXEPT/EZO-Common-T2-2B-gemma-2-it](https://huggingface.co/AXCXEPT/EZO-Common-T2-2B-gemma-2-it) | Gemma 2 (**2b**) || Axcxept | Gemma Terms of Use |
 | [Shisa V2.1 1.2B](https://shisa.ai/posts/shisa-v2.1/)<br>([**1.2b**](https://huggingface.co/shisa-ai/shisa-v2.1-lfm2-1.2b)) | LFM2 (**1.2b**) | Combinaison de SFT/DPO/RL/fusion de modèles | Shisa.AI | LFM Open License v1.0 |
 | [LFM2.5-1.2B-JP](https://www.liquid.ai/blog/introducing-lfm2-5-the-next-generation-of-on-device-ai)<br>([1.2B-JP](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP)) | LFM2.5 (**1.2b**) | Non divulgué | Liquid AI | LFM Open License v1.0 |
+| [Qwen3.5-FT-Japanese-CoT-0.8B](https://huggingface.co/Aname-Tommy/Qwen3.5-FT-Japanese-CoT-0.8B) | Qwen3.5 (**0.8b**) | Non divulgué | Individuel (Aname-Tommy) | MIT |
 
 <a id="generative-instruction-only-domain-specific"></a>
 #### Spécifique à un domaine


### PR DESCRIPTION
## Summary
- Qwen3.5-FT-Japanese-CoT (4B, 0.8B) を「海外モデルに日本語で追加学習を行ったモデル（事後学習のみ、または詳細不明）」セクションに追加
- CLAUDE.md に個人開発者の表記ルールを追記

Closes #609

## Test plan
- [ ] README.md, en/README.md, fr/README.md の3ファイルで同じ位置に追加されていることを確認
- [ ] パラメータサイズ降順が維持されていることを確認（4B: 7b と 3.8b の間、0.8B: 1.2b の後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)