### PR TITLE
Add Med-Asagi: 日本語医療VLM (#616)

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@
 
 |    |  アーキテクチャ  |  ドメイン | 開発元  | ライセンス |
 |:---|:---:|:---:|:---:|:---:|
+| [Med-Asagi](https://www.rcast.u-tokyo.ac.jp/ja/news/release/20260306.html)<br>([**14b**-reasoning_beta](https://huggingface.co/MIL-UT/Med-Asagi-14B-reasoning_beta)) | LLaVA | 医療 | 東大 原田研 | CC BY-SA 4.0 |
 | [watashiha/Watashiha-Llama-2-13B-Ogiri-sft-vlm](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft-vlm) | LLaVA | 大喜利 | わたしは | Llama 2 Community License |
 
 #### 海外モデルに日本語で追加学習を行ったモデル

--- a/en/README.md
+++ b/en/README.md
@@ -430,6 +430,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 
 |    |  Architecture  |  Domain |  Developer  | License |
 |:---|:---:|:---:|:---:|:---:|
+| [Med-Asagi](https://www.rcast.u-tokyo.ac.jp/ja/news/release/20260306.html)<br>([**14b**-reasoning_beta](https://huggingface.co/MIL-UT/Med-Asagi-14B-reasoning_beta)) | LLaVA | Medicine | University of Tokyo Machine Intelligence Lab. | CC BY-SA 4.0 |
 | [watashiha/Watashiha-Llama-2-13B-Ogiri-sft-vlm](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft-vlm) | LLaVA | [Oogiri](https://en.wikipedia.org/wiki/Glossary_of_owarai_terms#oogiri) | Watashiha | Llama 2 Community License |
 
 #### Models built off non-Japanese VLMs

--- a/fr/README.md
+++ b/fr/README.md
@@ -430,6 +430,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 
 |    | Architecture | Domaine |  Développeur  |  Licence  |
 |:---|:---:|:---:|:---:|:---:|
+| [Med-Asagi](https://www.rcast.u-tokyo.ac.jp/ja/news/release/20260306.html)<br>([**14b**-reasoning_beta](https://huggingface.co/MIL-UT/Med-Asagi-14B-reasoning_beta)) | LLaVA | Médecine | University of Tokyo Machine Intelligence Lab. | CC BY-SA 4.0 |
 | [watashiha/Watashiha-Llama-2-13B-Ogiri-sft-vlm](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft-vlm) | LLaVA | [Oogiri](https://en.wikipedia.org/wiki/Glossary_of_owarai_terms#oogiri) | Watashiha | Llama 2 Community License |
 
 #### Modèles développés à partir d'VLM non-japonais


### PR DESCRIPTION
## Summary
- Add Med-Asagi-14B-reasoning_beta to the domain-specific VLM section (Medicine)
- Developer: University of Tokyo Machine Intelligence Lab. (MIL-UT)
- Architecture: LLaVA, License: CC BY-SA 4.0
- Updated all three language versions (JA/EN/FR)

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)