### PR TITLE
Add Rakuten AI 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@
 
 |    | ベースのLLM  | 学習テキスト | 開発元  | ライセンス / 利用規約 |
 |:---|:---:|:---:|:---:|:---:|
+| [Rakuten AI 3.0](https://corp.rakuten.co.jp/news/press/2026/0317_01.html)<br>([RakutenAI-3.0](https://huggingface.co/Rakuten/RakutenAI-3.0)) | DeepSeek-V3 (**671b**) [^24] | 不明 | 楽天 | Apache 2.0 |
 | [Llama 3.1 Shisa V2 405B](https://shisa.ai/posts/shisa-v2-405b-ja-pr/)<br>([**405b**](https://huggingface.co/shisa-ai/shisa-v2-llama3.1-405b)) | Llama 3.1 (**405b**) | 高品質な日本語データセットでSFT/DPO | Shisa.AI | Llama 3.1 Community License |
 | [AXCXEPT/EZO-Qwen2.5-72B-Instruct](https://huggingface.co/AXCXEPT/EZO-Qwen2.5-72B-Instruct)<br>[AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4](https://huggingface.co/AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4) | Qwen2.5 (**72b**) || Axcxept | Qwen License |
 | [ao-Karasu](https://note.com/lightblue_tech/n/nfda12435b262)<br>([72B](https://huggingface.co/lightblue/ao-karasu-72B)) | Qwen1.5 (**72b**) | ultra-orca-boros-en-ja-v1, OASST1, ShareGPT, 日本語の公開技術ブログ, ニュース記事, QAサイトの回答, 独自のデータセット | Lightblue |  Tongyi Qianwen LICENSE (?)[^12] |
@@ -726,3 +727,5 @@
 [^22]: 一部アーキテクチャの変更を加えている。詳しくは以下を参照: [1,000億パラメータ規模の独自LLM「PLaMo-100B」の事前学習](https://tech.preferred.jp/ja/blog/plamo-100b/)
 
 [^23]: Llama から Causal Attention を取り除くことにより、エンコーダ型モデルとして利用している。
+
+[^24]: 公式にはベースモデルについて明言されていないが、HuggingFace リポジトリ上の config.json のアーキテクチャが `DeepseekV3ForCausalLM` であること、トークナイザが DeepSeek-V3 と一致すること、DeepSeek の NOTICE ファイルが含まれていることから、DeepSeek-V3 をベースにしている可能性が高い。

--- a/en/README.md
+++ b/en/README.md
@@ -209,6 +209,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 
 |    | Base Model  | Training Data  | Developer  |  License / Terms of Use |
 |:---|:---:|:---:|:---:|:---:|
+| [Rakuten AI 3.0](https://corp.rakuten.co.jp/news/press/2026/0317_01.html)<br>([RakutenAI-3.0](https://huggingface.co/Rakuten/RakutenAI-3.0)) | DeepSeek-V3 (**671b**) [^24] | Undisclosed | Rakuten | Apache 2.0 |
 | [Llama 3.1 Shisa V2 405B](https://shisa.ai/posts/shisa-v2-405b-ja-pr/)<br>([**405b**](https://huggingface.co/shisa-ai/shisa-v2-llama3.1-405b)) | Llama 3.1 (**405b**) | High-quality Japanese datasets with SFT/DPO | Shisa.AI | Llama 3.1 Community License |
 | [AXCXEPT/EZO-Qwen2.5-72B-Instruct](https://huggingface.co/AXCXEPT/EZO-Qwen2.5-72B-Instruct)<br>[AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4](https://huggingface.co/AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4) | Qwen2.5 (**72b**) || Axcxept | Qwen License |
 | [ao-Karasu](https://note.com/peter_lightblue/n/n483d194d3614)<br>([72B](https://huggingface.co/lightblue/ao-karasu-72B)) | Qwen1.5 (**72b**) | ultra-orca-boros-en-ja-v1, OASST1, ShareGPT, Japanese technical blogs, News stories, QA site answers, undisclosed dataset | Lightblue |  Tongyi Qianwen LICENSE (?)[^12] |
@@ -726,3 +727,5 @@ When referencing this repository, please cite as follows:
 [^22]: Some architectural changes have been made. For details, refer to: [1,000億パラメータ規模の独自LLM「PLaMo-100B」の事前学習](https://tech.preferred.jp/ja/blog/plamo-100b/)
 
 [^23]: By removing Causal Attention from Llama, it is used as an encoder-type model.
+
+[^24]: Although the base model is not officially disclosed, the config.json architecture is `DeepseekV3ForCausalLM`, the tokenizer is identical to DeepSeek-V3, and the repository includes a DeepSeek NOTICE file, strongly suggesting it is based on DeepSeek-V3.

--- a/fr/README.md
+++ b/fr/README.md
@@ -209,6 +209,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 
 |    | Base du Model  |  Données d'entraînement  |  Développeur  |  Licence / Conditions d'utilisation  |
 |:---|:---:|:---:|:---:|:---:|
+| [Rakuten AI 3.0](https://corp.rakuten.co.jp/news/press/2026/0317_01.html)<br>([RakutenAI-3.0](https://huggingface.co/Rakuten/RakutenAI-3.0)) | DeepSeek-V3 (**671b**) [^24] | Non divulgué | Rakuten | Apache 2.0 |
 | [Llama 3.1 Shisa V2 405B](https://shisa.ai/posts/shisa-v2-405b-ja-pr/)<br>([**405b**](https://huggingface.co/shisa-ai/shisa-v2-llama3.1-405b)) | Llama 3.1 (**405b**) | Jeux de données japonais de haute qualité avec SFT/DPO | Shisa.AI | Llama 3.1 Community License |
 | [AXCXEPT/EZO-Qwen2.5-72B-Instruct](https://huggingface.co/AXCXEPT/EZO-Qwen2.5-72B-Instruct)<br>[AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4](https://huggingface.co/AXCXEPT/EZO-AutoCoTRAG-Qwen2.5-72B-Instruct_q4) | Qwen2.5 (**72b**) || Axcxept | Qwen License |
 | [ao-Karasu](https://note.com/peter_lightblue/n/n483d194d3614)<br>([72B](https://huggingface.co/lightblue/ao-karasu-72B)) | Qwen1.5 (**72b**) | ultra-orca-boros-en-ja-v1, OASST1, ShareGPT, Japanese technical blogs, News stories, QA site answers, undisclosed dataset | Lightblue |  Tongyi Qianwen LICENSE (?)[^12] |
@@ -726,3 +727,5 @@ Lorsque vous référencez ce répertoire, veuillez le citer comme suit:
 [^22]: Quelques modifications architecturales ont été apportées. Pour plus de détails, référez-vous à : [1,000億パラメータ規模の独自LLM「PLaMo-100B」の事前学習](https://tech.preferred.jp/ja/blog/plamo-100b/)
 
 [^23]: En supprimant l'attention causale de Llama, il est utilisé comme un modèle de type encodeur.
+
+[^24]: Bien que le modèle de base ne soit pas officiellement divulgué, l'architecture dans config.json est `DeepseekV3ForCausalLM`, le tokenizer est identique à celui de DeepSeek-V3, et le dépôt contient un fichier NOTICE de DeepSeek, ce qui suggère fortement qu'il est basé sur DeepSeek-V3.


### PR DESCRIPTION
## Summary
- Add Rakuten AI 3.0 (671B MoE) to the "post-training only, or details unknown" section in all three languages (JA/EN/FR)
- Base model is suspected to be DeepSeek-V3 based on config.json architecture (`DeepseekV3ForCausalLM`), identical tokenizer, and included DeepSeek NOTICE file — added as footnote [^24]

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)