### PR TITLE
KARAKURI VL 2 8B Thinking 2603 を追加

### DIFF
--- a/.claude/rules/vlm-addition.md
+++ b/.claude/rules/vlm-addition.md
@@ -7,11 +7,17 @@ paths:
 
 # VLM Addition Guidelines
 
-## VLM Sections
+## VLM Section Classification
 
-1. **スクラッチ学習モデル**: New VLM combining Japanese LLM + vision encoder
-2. **海外モデルに日本語で追加学習**: Existing foreign VLM with Japanese training added
-3. **マージモデル**: VLMs created by merging techniques
+Classify each model independently based on its own training approach. Do NOT assume section placement based on other models from the same developer.
+
+| Section | Criteria |
+|---------|----------|
+| スクラッチ学習モデル | New VLM built from scratch, typically combining a Japanese LLM + vision encoder with substantial multi-stage training |
+| 海外モデルに日本語で追加学習 | Fine-tuned from an existing foreign VLM (e.g., Qwen-VL, InternVL). If the base model is a foreign VLM, it belongs here regardless of training scale |
+| マージモデル | VLMs created by merging techniques |
+
+**Critical Rule:** Always check the base model. If a model is fine-tuned from a foreign VLM (e.g., `Qwen3-VL-8B-Thinking`), it belongs in 「海外モデルに日本語で追加学習」, even if other models from the same developer are in a different section.
 
 ## VLM Ordering
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@
 |    |  ベースのVLM  |  学習画像/テキスト  |  開発元  | ライセンス |
 |:---|:---:|:---:|:---:|:---:|
 | [AXCXEPT/EZO-InternVL2-26B](https://huggingface.co/AXCXEPT/EZO-InternVL2-26B) | InternVL2 | - | 　Axcxept | MIT |
+| [KARAKURI VL 2](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)<br>([**8b**-thinking-2603](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)) | Qwen3-VL-8B-Thinking | 不明 | カラクリ | Apache 2.0 |
 
 #### 複数のVLM・LLMをマージして作成されたモデル
 

--- a/en/README.md
+++ b/en/README.md
@@ -440,6 +440,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 |    |  Base Model  |  Training Data  |  Developer  | License |
 |:---|:---:|:---:|:---:|:---:|
 | [AXCXEPT/EZO-InternVL2-26B](https://huggingface.co/AXCXEPT/EZO-InternVL2-26B) | InternVL2 | - | 　Axcxept | MIT |
+| [KARAKURI VL 2](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)<br>([**8b**-thinking-2603](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)) | Qwen3-VL-8B-Thinking | Undisclosed | KARAKURI | Apache 2.0 |
 
 #### Merged models
 

--- a/fr/README.md
+++ b/fr/README.md
@@ -440,6 +440,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 |    | Base du Model |  Données d'entraînement  |  Développeur  | Licence |
 |:---|:---:|:---:|:---:|:---:|
 | [AXCXEPT/EZO-InternVL2-26B](https://huggingface.co/AXCXEPT/EZO-InternVL2-26B) | InternVL2 | - | 　Axcxept | MIT |
+| [KARAKURI VL 2](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)<br>([**8b**-thinking-2603](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)) | Qwen3-VL-8B-Thinking | Non divulgué | KARAKURI | Apache 2.0 |
 
 #### Modèles fusionnés
 


### PR DESCRIPTION
## Summary
- KARAKURI VL 2 (8b-thinking-2603) を VLM > 海外モデルに日本語で追加学習を行ったモデル セクションに追加
- ベースモデル: Qwen3-VL-8B-Thinking
- 開発元: カラクリ / ライセンス: Apache 2.0
- VLM セクション分類ルール (.claude/rules/vlm-addition.md) を明確化

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)