### PR TITLE
Add OneComp (富士通研究所) to quantization tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,3 +737,5 @@
 [^23]: Llama から Causal Attention を取り除くことにより、エンコーダ型モデルとして利用している。
 
 [^24]: 公式にはベースモデルについて明言されていないが、HuggingFace リポジトリ上の config.json のアーキテクチャが `DeepseekV3ForCausalLM` であること、トークナイザが DeepSeek-V3 と一致すること、DeepSeek の NOTICE ファイルが含まれていることから、DeepSeek-V3 をベースにしている可能性が高い。
+
+- **[OneComp](https://github.com/FujitsuResearch/OneCompression)** ([arXiv:2603.28845](https://arxiv.org/abs/2603.28845)) — 富士通研究所による LLM 向けの PTQ パイプライン。量子化誤差伝播 (QEP, NeurIPS 2025)、ILP ベース混合精度割当 (AutoBit)、重み・スケール共同最適化 (JointQ)、SpinQuant/OstQuant 系の回転前処理、LoRA SFT 後処理、vLLM プラグインを提供。Llama / Qwen3 に対応済み。Apache-2.0。


### PR DESCRIPTION
## Summary

This PR adds **OneComp** (Fujitsu Research, [arXiv:2603.28845](https://arxiv.org/abs/2603.28845)) and its accompanying NeurIPS 2025 paper **QEP** to this awesome list.

OneComp is an open-source, Apache-2.0 licensed post-training quantization (PTQ) framework for LLMs that unifies several recent research directions behind a single `Runner.auto_run()` API:

- **QEP** (Quantization Error Propagation, NeurIPS 2025) — layer-wise PTQ with propagated error compensation.
- **AutoBit** — ILP-based mixed-precision bitwidth assignment derived from available VRAM.
- **JointQ** — joint weight–scale optimization (group-wise 4-bit, etc.).
- **Rotation preprocessing** — SpinQuant/OstQuant-style learned rotations absorbed into weights, with online Hadamard hooks at load time.
- **LoRA SFT post-process** — accuracy recovery / knowledge injection after quantization.
- **vLLM plugin** — first-class DBF & Mixed-GPTQ serving of OneComp checkpoints.

Verified on Llama (TinyLlama / Llama-2 / Llama-3) and Qwen3 (0.6B — 32B). PyPI: `pip install onecomp`.

Links:
- Repo: https://github.com/FujitsuResearch/OneCompression
- Paper (OneComp): https://arxiv.org/abs/2603.28845
- Paper (QEP, NeurIPS 2025): https://openreview.net/forum?id=a3l3K9khbL
- Docs: https://FujitsuResearch.github.io/OneCompression/

Happy to adjust section placement, wording, or formatting to better match the list's conventions — thanks for maintaining this resource!
