### PR TITLE
Qwen-3-VL-Ricoh-8B-20260227 を追加

### DIFF
--- a/.claude/rules/model-addition.md
+++ b/.claude/rules/model-addition.md
@@ -33,9 +33,20 @@ Models are classified into sections based on training approach. **Evidence is re
 
 ## Information Verification Checklist
 
-1. **HuggingFace config.json**: Parameter count, context length (`max_position_embeddings`)
-2. **HuggingFace README**: Training methodology, base model, license
-3. **Official announcement/blog**: Release year, developer, training details
-4. **LICENSE file**: Full official license name (e.g., "LFM Open License v1.0", not "lfm1.0")
+1. **HuggingFace Model tree** (right sidebar): **Authoritative source for `base_model`**. Always check this BEFORE relying on prose in the model card.
+2. **HuggingFace config.json**: Parameter count, context length (`max_position_embeddings`)
+3. **HuggingFace README**: Training methodology, license (cross-check base model against Model tree)
+4. **Official announcement/blog**: Release year, developer, training details
+5. **LICENSE file**: Full official license name (e.g., "LFM Open License v1.0", not "lfm1.0")
+
+**Base model verification**: Model card prose may list multiple models (e.g., "based on A and B" / "AおよびBをもとに開発") as acknowledgment, even when only one is the technical base. The HuggingFace Model tree's `base_model` field is the structured ground truth — trust it over prose. If the Model tree is gated/inaccessible, ask the user for a screenshot rather than guessing.
 
 **Cross-source verification**: When numeric values (e.g., token counts) appear in multiple sources, always cross-check. HuggingFace READMEs may contain approximations or unit errors (e.g., "~1.8B tokens" vs actual "1.8億トークン" = 0.18B). Prefer official blog posts or papers for precise numbers.
+
+**Press release scope check**: Press releases often describe a model family (e.g., 32B + 8B). Training details quoted from a press release may apply only to the flagship variant. Match each claim to the specific size/variant being added.
+
+**WebFetch summary caveats**: WebFetch returns AI-summarized content that can:
+- Conflate future plans ("will utilize X") with applied techniques ("used X")
+- Flatten "based on (acknowledgment)" into "merged from / fine-tuned from"
+- Drop tense and conditional markers
+When a WebFetch summary mentions "merged", "based on multiple", or any training method, re-fetch with a quote-only prompt or read the page directly to verify.

--- a/.claude/rules/vlm-addition.md
+++ b/.claude/rules/vlm-addition.md
@@ -19,6 +19,8 @@ Classify each model independently based on its own training approach. Do NOT ass
 
 **Critical Rule:** Always check the base model. If a model is fine-tuned from a foreign VLM (e.g., `Qwen3-VL-8B-Thinking`), it belongs in 「海外モデルに日本語で追加学習」, even if other models from the same developer are in a different section.
 
+**How to identify the base model:** Use the HuggingFace **Model tree** (right sidebar) — this is the structured ground truth. Do NOT rely solely on model card prose like "○○および△△をもとに開発" / "based on A and B", which often lists multiple models for acknowledgment even when only one is the technical base. See `model-addition.md` for the full verification checklist.
+
 ## VLM Ordering
 
 - Same parameter size ordering as LLMs (descending)

--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@
 |:---|:---:|:---:|:---:|:---:|
 | [AXCXEPT/EZO-InternVL2-26B](https://huggingface.co/AXCXEPT/EZO-InternVL2-26B) | InternVL2 | - | 　Axcxept | MIT |
 | [KARAKURI VL 2](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)<br>([**8b**-thinking-2603](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)) | Qwen3-VL-8B-Thinking | 不明 | カラクリ | Apache 2.0 |
+| [Qwen-3-VL-Ricoh-8B-20260227](https://jp.ricoh.com/release/2026/0330_1)<br>([**8B**-20260227](https://huggingface.co/ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227)) | Qwen3-VL-8B-Thinking | 強化学習 (RL) による推論プロセスの導入 | リコー | Apache 2.0 |
 
 #### 複数のVLM・LLMをマージして作成されたモデル
 

--- a/en/README.md
+++ b/en/README.md
@@ -447,6 +447,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 |:---|:---:|:---:|:---:|:---:|
 | [AXCXEPT/EZO-InternVL2-26B](https://huggingface.co/AXCXEPT/EZO-InternVL2-26B) | InternVL2 | - | 　Axcxept | MIT |
 | [KARAKURI VL 2](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)<br>([**8b**-thinking-2603](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)) | Qwen3-VL-8B-Thinking | Undisclosed | KARAKURI | Apache 2.0 |
+| [Qwen-3-VL-Ricoh-8B-20260227](https://jp.ricoh.com/release/2026/0330_1)<br>([**8B**-20260227](https://huggingface.co/ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227)) | Qwen3-VL-8B-Thinking | Reasoning process via Reinforcement Learning (RL) | Ricoh | Apache 2.0 |
 
 #### Merged models
 

--- a/fr/README.md
+++ b/fr/README.md
@@ -447,6 +447,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 |:---|:---:|:---:|:---:|:---:|
 | [AXCXEPT/EZO-InternVL2-26B](https://huggingface.co/AXCXEPT/EZO-InternVL2-26B) | InternVL2 | - | 　Axcxept | MIT |
 | [KARAKURI VL 2](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)<br>([**8b**-thinking-2603](https://huggingface.co/karakuri-ai/karakuri-vl-2-8b-thinking-2603)) | Qwen3-VL-8B-Thinking | Non divulgué | KARAKURI | Apache 2.0 |
+| [Qwen-3-VL-Ricoh-8B-20260227](https://jp.ricoh.com/release/2026/0330_1)<br>([**8B**-20260227](https://huggingface.co/ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227)) | Qwen3-VL-8B-Thinking | Processus de raisonnement par apprentissage par renforcement (RL) | Ricoh | Apache 2.0 |
 
 #### Modèles fusionnés
 


### PR DESCRIPTION
## Summary

- 視覚言語モデル「海外モデルに日本語で追加学習」セクションに [Qwen-3-VL-Ricoh-8B-20260227](https://huggingface.co/ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227) を追加（日・英・仏 README）
- ベース: Qwen3-VL-8B-Thinking（HuggingFace Model tree より確認）
- 訓練手法: 強化学習 (RL) による推論プロセスの導入
- ライセンス: Apache 2.0
- 開発元: リコー（GENIAC Project）
- 参考: [プレスリリース](https://jp.ricoh.com/release/2026/0330_1)

## Editing rules updates

副次的に `.claude/rules/` も更新:
- `model-addition.md`: 検証チェックリストに HuggingFace Model tree を最優先項目として追加。プレスリリースのスコープ確認・WebFetch 要約の落とし穴に関する注意書きを追加
- `vlm-addition.md`: ベースモデル特定方法として Model tree を参照する旨を追記

closes #629