### PR TITLE
海外モデルに日本語で継続事前学習を行ったモデル / ドメイン特化型 の表に公開年列を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,22 +196,22 @@
 <a id="generative-continual-domain-specific"></a>
 #### ドメイン特化型
 
-|    | ドメイン | ベースのLLM  |  開発元  | ライセンス |
-|:---|:---:|:---:|:---:|:---:|
-| [pfnet/Preferred-MedLLM-Qwen-72B](https://huggingface.co/pfnet/Preferred-MedLLM-Qwen-72B) | 医療 | Qwen2.5 (**72b**) | Preferred Networks | Qwen LICENSE |
-| [Llama3-Preferred-MedSwallow-70B](https://tech.preferred.jp/ja/blog/llama3-preferred-medswallow-70b/)<br>([70B](https://huggingface.co/pfnet/Llama3-Preferred-MedSwallow-70B)) | 医療 | Llama 3 (**70b**) | Preferred Networks | Llama 3 Community License |
-| [AIgroup-CVM-utokyohospital/MedSwallow-70b](https://huggingface.co/AIgroup-CVM-utokyohospital/MedSwallow-70b) | 医療 | Llama 2 (**70b**) | 東京大学医学部附属病院 循環器内科 AIグループ | CC BY-NC-SA 4.0 |
-| [gpt-oss-20b-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-Thinking)) | 金融 | GPT-OSS (**20b**) | 野村総合研究所 | Apache 2.0 |
-| [nekomata-14b-pfn-qfin](https://tech.preferred.jp/ja/blog/qfin-llm-continual-pretraining/)<br>([qfin](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin), [qfin-inst-merge](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin-inst-merge)) | 金融 | Qwen (**14b**) | Preferred Networks | Tongyi Qianwen LICENSE |
-| [Qwen3-14B-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-Thinking)) | 金融 | Qwen3 (**14b**) | 野村総合研究所 | Apache 2.0 |
-| [Watashiha-Llama-2-13B-Ogiri-sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft)<br>([sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft), [sft-neuron](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft-neuron)) | 大喜利 | Llama 2 (**13b**) | わたしは | Llama 2 Community License |
-| [MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5](https://huggingface.co/IngentaAITeam/MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5) | 医療 | Llama 3.1 (**8b**) | Ingenta | Llama 3.1 Community License |
-| [からまる](https://sakana.ai/karamaru/)<br>([Karamaru-v1](https://huggingface.co/SakanaAI/Llama-3-Karamaru-v1)) | 江戸時代の古文 | Llama 3 (**8b**) | Sakana AI | Llama 3 Community License |
-| [Llama 3.1 Future Code Ja 8B](https://huggingface.co/future-architect/Llama-3.1-Future-Code-Ja-8B) | コーディング | Llama 3.1<br>(**8b**) | フューチャー | Llama 3.1 Community License |
-| [JPharmatron](https://huggingface.co/collections/EQUES/pharmatron-680a330b4dfce3ac43009984)<br>([7B-base](https://huggingface.co/EQUES/JPharmatron-7B-base), [7B](https://huggingface.co/EQUES/JPharmatron-7B)) | 薬学 | Qwen2.5 (**7b**) | EQUES Inc. | CC BY-SA 4.0 |
-| [ELYZA-japanese-CodeLlama-7b](https://note.com/elyza/n/n5bce23d7c9c8)<br>([7b](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b), [7b-instruct](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b-instruct)) | コーディング |  Code Llama<br>(**7b**) | ELYZA | Llama 2 Community License |
-| [AIBunCho/japanese-novel-gpt-j-6b](https://huggingface.co/AIBunCho/japanese-novel-gpt-j-6b) | 物語生成 | GPT-J (**6b**) | 個人 ([大曽根宏幸](https://scholar.google.co.jp/citations?user=6ID5K3oAAAAJ)) | CreativeML OpenRAIL-M License |
-| [NovelAI/genji-jp](https://huggingface.co/NovelAI/genji-jp) | 物語生成 | GPT-J (**6b**) | NovelAI |  ？  |
+|    | 公開年 | ドメイン | ベースのLLM  |  開発元  | ライセンス |
+|:---|:---:|:---:|:---:|:---:|:---:|
+| [pfnet/Preferred-MedLLM-Qwen-72B](https://huggingface.co/pfnet/Preferred-MedLLM-Qwen-72B) | 2025 | 医療 | Qwen2.5 (**72b**) | Preferred Networks | Qwen LICENSE |
+| [Llama3-Preferred-MedSwallow-70B](https://tech.preferred.jp/ja/blog/llama3-preferred-medswallow-70b/)<br>([70B](https://huggingface.co/pfnet/Llama3-Preferred-MedSwallow-70B)) | 2024 | 医療 | Llama 3 (**70b**) | Preferred Networks | Llama 3 Community License |
+| [AIgroup-CVM-utokyohospital/MedSwallow-70b](https://huggingface.co/AIgroup-CVM-utokyohospital/MedSwallow-70b) | 2024 | 医療 | Llama 2 (**70b**) | 東京大学医学部附属病院 循環器内科 AIグループ | CC BY-NC-SA 4.0 |
+| [gpt-oss-20b-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-Thinking)) | **2026** | 金融 | GPT-OSS (**20b**) | 野村総合研究所 | Apache 2.0 |
+| [nekomata-14b-pfn-qfin](https://tech.preferred.jp/ja/blog/qfin-llm-continual-pretraining/)<br>([qfin](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin), [qfin-inst-merge](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin-inst-merge)) | 2024 | 金融 | Qwen (**14b**) | Preferred Networks | Tongyi Qianwen LICENSE |
+| [Qwen3-14B-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-Thinking)) | **2026** | 金融 | Qwen3 (**14b**) | 野村総合研究所 | Apache 2.0 |
+| [Watashiha-Llama-2-13B-Ogiri-sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft)<br>([sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft), [sft-neuron](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft-neuron)) | 2024 | 大喜利 | Llama 2 (**13b**) | わたしは | Llama 2 Community License |
+| [MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5](https://huggingface.co/IngentaAITeam/MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5) | 2025 | 医療 | Llama 3.1 (**8b**) | Ingenta | Llama 3.1 Community License |
+| [からまる](https://sakana.ai/karamaru/)<br>([Karamaru-v1](https://huggingface.co/SakanaAI/Llama-3-Karamaru-v1)) | 2025 | 江戸時代の古文 | Llama 3 (**8b**) | Sakana AI | Llama 3 Community License |
+| [Llama 3.1 Future Code Ja 8B](https://huggingface.co/future-architect/Llama-3.1-Future-Code-Ja-8B) | 2025 | コーディング | Llama 3.1<br>(**8b**) | フューチャー | Llama 3.1 Community License |
+| [JPharmatron](https://huggingface.co/collections/EQUES/pharmatron-680a330b4dfce3ac43009984)<br>([7B-base](https://huggingface.co/EQUES/JPharmatron-7B-base), [7B](https://huggingface.co/EQUES/JPharmatron-7B)) | 2025 | 薬学 | Qwen2.5 (**7b**) | EQUES Inc. | CC BY-SA 4.0 |
+| [ELYZA-japanese-CodeLlama-7b](https://note.com/elyza/n/n5bce23d7c9c8)<br>([7b](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b), [7b-instruct](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b-instruct)) | 2023 | コーディング |  Code Llama<br>(**7b**) | ELYZA | Llama 2 Community License |
+| [AIBunCho/japanese-novel-gpt-j-6b](https://huggingface.co/AIBunCho/japanese-novel-gpt-j-6b) | 2023 | 物語生成 | GPT-J (**6b**) | 個人 ([大曽根宏幸](https://scholar.google.co.jp/citations?user=6ID5K3oAAAAJ)) | CreativeML OpenRAIL-M License |
+| [NovelAI/genji-jp](https://huggingface.co/NovelAI/genji-jp) | 2022 | 物語生成 | GPT-J (**6b**) | NovelAI |  ？  |
 
 <a id="instruction-only-models"></a>
 ### 海外モデルに日本語で事後学習を行ったモデル（継続事前学習なし、または詳細不明）

--- a/en/README.md
+++ b/en/README.md
@@ -196,22 +196,22 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 <a id="generative-continual-domain-specific"></a>
 #### Domain specific
 
-|    | Domain | Base Model  |  Developer  |  License  |
-|:---|:---:|:---:|:---:|:---:|
-| [pfnet/Preferred-MedLLM-Qwen-72B](https://huggingface.co/pfnet/Preferred-MedLLM-Qwen-72B) | Medicine | Qwen2.5 (**72b**) | Preferred Networks | Qwen LICENSE |
-| [Llama3-Preferred-MedSwallow-70B](https://tech.preferred.jp/ja/blog/llama3-preferred-medswallow-70b/)<br>([70B](https://huggingface.co/pfnet/Llama3-Preferred-MedSwallow-70B)) | Medicine | Llama 3 (**70b**) | Preferred Networks | Llama 3 Community License |
-| [AIgroup-CVM-utokyohospital/MedSwallow-70b](https://huggingface.co/AIgroup-CVM-utokyohospital/MedSwallow-70b) | Medicine | Llama 2 (**70b**) | University of Tokyo Hospital Department of Cardiovascular Medicine AI Group | CC BY-NC-SA 4.0 |
-| [gpt-oss-20b-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-Thinking)) | Finance | GPT-OSS (**20b**) | Nomura Research Institute | Apache 2.0 |
-| [nekomata-14b-pfn-qfin](https://arxiv.org/pdf/2404.10555)<br>([qfin](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin), [qfin-inst-merge](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin-inst-merge)) | Finance | Qwen (**14b**) | Preferred Networks | Tongyi Qianwen LICENSE |
-| [Qwen3-14B-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-Thinking)) | Finance | Qwen3 (**14b**) | Nomura Research Institute | Apache 2.0 |
-| [Watashiha-Llama-2-13B-Ogiri-sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft/blob/main/README_en.md)<br>([sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft), [sft-neuron](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft-neuron)) | [Oogiri](https://en.wikipedia.org/wiki/Glossary_of_owarai_terms#oogiri) | Llama 2 (**13b**) | Watashiha | Llama 2 Community License |
-| [MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5](https://huggingface.co/IngentaAITeam/MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5) | Medicine | Llama 3.1 (**8b**) | Ingenta | Llama 3.1 Community License |
-| [Llama 3.1 Future Code Ja 8B](https://huggingface.co/future-architect/Llama-3.1-Future-Code-Ja-8B) | Coding | Llama 3.1 (**8b**) | Future Corp. | Llama 3.1 Community License |
-| [Karamaru](https://sakana.ai/karamaru/)<br>([Karamaru-v1](https://huggingface.co/SakanaAI/Llama-3-Karamaru-v1)) | Edo-period Japanese | Llama 3 (**8b**) | Sakana AI | Llama 3 Community License |
-| [JPharmatron](https://huggingface.co/collections/EQUES/pharmatron-680a330b4dfce3ac43009984)<br>([7B-base](https://huggingface.co/EQUES/JPharmatron-7B-base), [7B](https://huggingface.co/EQUES/JPharmatron-7B)) | Pharmaceutical | Qwen2.5 (**7b**) | EQUES Inc. | CC BY-SA 4.0 |
-| [ELYZA-japanese-CodeLlama-7b](https://note.com/elyza/n/n5bce23d7c9c8)<br>([7b](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b), [7b-instruct](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b-instruct)) | Coding | Code Llama<br>(**7b**) | ELYZA | Llama 2 Community License |
-| [AIBunCho/japanese-novel-gpt-j-6b](https://huggingface.co/AIBunCho/japanese-novel-gpt-j-6b) | Storytelling | GPT-J (**6b**) | Individual ([Hiroyuki Osone](https://scholar.google.co.jp/citations?user=6ID5K3oAAAAJ)) | CreativeML OpenRAIL-M License |
-| [NovelAI/genji-jp](https://huggingface.co/NovelAI/genji-jp) | Storytelling | GPT-J (**6b**) | NovelAI |  ？  |
+|    | Release Year | Domain | Base Model  |  Developer  |  License  |
+|:---|:---:|:---:|:---:|:---:|:---:|
+| [pfnet/Preferred-MedLLM-Qwen-72B](https://huggingface.co/pfnet/Preferred-MedLLM-Qwen-72B) | 2025 | Medicine | Qwen2.5 (**72b**) | Preferred Networks | Qwen LICENSE |
+| [Llama3-Preferred-MedSwallow-70B](https://tech.preferred.jp/ja/blog/llama3-preferred-medswallow-70b/)<br>([70B](https://huggingface.co/pfnet/Llama3-Preferred-MedSwallow-70B)) | 2024 | Medicine | Llama 3 (**70b**) | Preferred Networks | Llama 3 Community License |
+| [AIgroup-CVM-utokyohospital/MedSwallow-70b](https://huggingface.co/AIgroup-CVM-utokyohospital/MedSwallow-70b) | 2024 | Medicine | Llama 2 (**70b**) | University of Tokyo Hospital Department of Cardiovascular Medicine AI Group | CC BY-NC-SA 4.0 |
+| [gpt-oss-20b-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-Thinking)) | **2026** | Finance | GPT-OSS (**20b**) | Nomura Research Institute | Apache 2.0 |
+| [nekomata-14b-pfn-qfin](https://arxiv.org/pdf/2404.10555)<br>([qfin](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin), [qfin-inst-merge](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin-inst-merge)) | 2024 | Finance | Qwen (**14b**) | Preferred Networks | Tongyi Qianwen LICENSE |
+| [Qwen3-14B-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-Thinking)) | **2026** | Finance | Qwen3 (**14b**) | Nomura Research Institute | Apache 2.0 |
+| [Watashiha-Llama-2-13B-Ogiri-sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft/blob/main/README_en.md)<br>([sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft), [sft-neuron](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft-neuron)) | 2024 | [Oogiri](https://en.wikipedia.org/wiki/Glossary_of_owarai_terms#oogiri) | Llama 2 (**13b**) | Watashiha | Llama 2 Community License |
+| [MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5](https://huggingface.co/IngentaAITeam/MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5) | 2025 | Medicine | Llama 3.1 (**8b**) | Ingenta | Llama 3.1 Community License |
+| [Llama 3.1 Future Code Ja 8B](https://huggingface.co/future-architect/Llama-3.1-Future-Code-Ja-8B) | 2025 | Coding | Llama 3.1 (**8b**) | Future Corp. | Llama 3.1 Community License |
+| [Karamaru](https://sakana.ai/karamaru/)<br>([Karamaru-v1](https://huggingface.co/SakanaAI/Llama-3-Karamaru-v1)) | 2025 | Edo-period Japanese | Llama 3 (**8b**) | Sakana AI | Llama 3 Community License |
+| [JPharmatron](https://huggingface.co/collections/EQUES/pharmatron-680a330b4dfce3ac43009984)<br>([7B-base](https://huggingface.co/EQUES/JPharmatron-7B-base), [7B](https://huggingface.co/EQUES/JPharmatron-7B)) | 2025 | Pharmaceutical | Qwen2.5 (**7b**) | EQUES Inc. | CC BY-SA 4.0 |
+| [ELYZA-japanese-CodeLlama-7b](https://note.com/elyza/n/n5bce23d7c9c8)<br>([7b](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b), [7b-instruct](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b-instruct)) | 2023 | Coding | Code Llama<br>(**7b**) | ELYZA | Llama 2 Community License |
+| [AIBunCho/japanese-novel-gpt-j-6b](https://huggingface.co/AIBunCho/japanese-novel-gpt-j-6b) | 2023 | Storytelling | GPT-J (**6b**) | Individual ([Hiroyuki Osone](https://scholar.google.co.jp/citations?user=6ID5K3oAAAAJ)) | CreativeML OpenRAIL-M License |
+| [NovelAI/genji-jp](https://huggingface.co/NovelAI/genji-jp) | 2022 | Storytelling | GPT-J (**6b**) | NovelAI |  ？  |
 
 <a id="instruction-only-models"></a>
 ### Models built off non-Japanese LLMs (post-training only, no continual pre-training or details unknown)

--- a/fr/README.md
+++ b/fr/README.md
@@ -196,22 +196,22 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 <a id="generative-continual-domain-specific"></a>
 #### Spécifique à un domaine
 
-|    | Domaine | Base du Model  |  Développeur  |  Licence  |
-|:---|:---:|:---:|:---:|:---:|
-| [pfnet/Preferred-MedLLM-Qwen-72B](https://huggingface.co/pfnet/Preferred-MedLLM-Qwen-72B) | Médecine | Qwen2.5 (**72b**) | Preferred Networks | Qwen LICENSE |
-| [Llama3-Preferred-MedSwallow-70B](https://tech.preferred.jp/ja/blog/llama3-preferred-medswallow-70b/)<br>([70B](https://huggingface.co/pfnet/Llama3-Preferred-MedSwallow-70B)) | Médecine | Llama 3 (**70b**) | Preferred Networks | Llama 3 Community License |
-| [AIgroup-CVM-utokyohospital/MedSwallow-70b](https://huggingface.co/AIgroup-CVM-utokyohospital/MedSwallow-70b) | Médecine | Llama 2 (**70b**) | Université de Tokyo - AI Group du Département hospitalier de médecine cardiovasculaire | CC BY-NC-SA 4.0 |
-| [gpt-oss-20b-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-Thinking)) | Finance | GPT-OSS (**20b**) | Nomura Research Institute | Apache 2.0 |
-| [nekomata-14b-pfn-qfin](https://arxiv.org/pdf/2404.10555)<br>([qfin](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin), [qfin-inst-merge](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin-inst-merge)) | Finance | Qwen (**14b**) | Preferred Networks | Tongyi Qianwen LICENSE |
-| [Qwen3-14B-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-Thinking)) | Finance | Qwen3 (**14b**) | Nomura Research Institute | Apache 2.0 |
-| [Watashiha-Llama-2-13B-Ogiri-sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft/blob/main/README_en.md)<br>([sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft), [sft-neuron](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft-neuron)) | [Oogiri](https://en.wikipedia.org/wiki/Glossary_of_owarai_terms#oogiri)| Llama 2 (**13b**) | Watashiha | Llama 2 Community License |
-| [MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5](https://huggingface.co/IngentaAITeam/MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5) | Médecine | Llama 3.1 (**8b**) | Ingenta | Llama 3.1 Community License |
-| [Karamaru](https://sakana.ai/karamaru/)<br>([Karamaru-v1](https://huggingface.co/SakanaAI/Llama-3-Karamaru-v1)) | Edo-period Japanese | Llama 3 (**8b**) | Sakana AI | Llama 3 Community License |
-| [Llama 3.1 Future Code Ja 8B](https://huggingface.co/future-architect/Llama-3.1-Future-Code-Ja-8B) | Codage | Llama 3.1 (**8b**) | Future Corp. | Llama 3.1 Community License |
-| [JPharmatron](https://huggingface.co/collections/EQUES/pharmatron-680a330b4dfce3ac43009984)<br>([7B-base](https://huggingface.co/EQUES/JPharmatron-7B-base), [7B](https://huggingface.co/EQUES/JPharmatron-7B)) | Pharmaceutique | Qwen2.5 (**7b**) | EQUES Inc. | CC BY-SA 4.0 |
-| [ELYZA-japanese-CodeLlama-7b](https://note.com/elyza/n/n5bce23d7c9c8)<br>([7b](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b), [7b-instruct](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b-instruct)) | Codage | Code Llama<br>(**7b**) | ELYZA | Llama 2 Community License |
-| [AIBunCho/japanese-novel-gpt-j-6b](https://huggingface.co/AIBunCho/japanese-novel-gpt-j-6b) | Génération de récits | GPT-J (**6b**) | Individuel ([Hiroyuki Osone](https://scholar.google.co.jp/citations?user=6ID5K3oAAAAJ)) | CreativeML OpenRAIL-M License |
-| [NovelAI/genji-jp](https://huggingface.co/NovelAI/genji-jp) | Génération de récits | GPT-J (**6b**) | NovelAI |  ？  |
+|    | Année de sortie | Domaine | Base du Model  |  Développeur  |  Licence  |
+|:---|:---:|:---:|:---:|:---:|:---:|
+| [pfnet/Preferred-MedLLM-Qwen-72B](https://huggingface.co/pfnet/Preferred-MedLLM-Qwen-72B) | 2025 | Médecine | Qwen2.5 (**72b**) | Preferred Networks | Qwen LICENSE |
+| [Llama3-Preferred-MedSwallow-70B](https://tech.preferred.jp/ja/blog/llama3-preferred-medswallow-70b/)<br>([70B](https://huggingface.co/pfnet/Llama3-Preferred-MedSwallow-70B)) | 2024 | Médecine | Llama 3 (**70b**) | Preferred Networks | Llama 3 Community License |
+| [AIgroup-CVM-utokyohospital/MedSwallow-70b](https://huggingface.co/AIgroup-CVM-utokyohospital/MedSwallow-70b) | 2024 | Médecine | Llama 2 (**70b**) | Université de Tokyo - AI Group du Département hospitalier de médecine cardiovasculaire | CC BY-NC-SA 4.0 |
+| [gpt-oss-20b-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/gpt-oss-20b-Ja-Fin-Thinking)) | **2026** | Finance | GPT-OSS (**20b**) | Nomura Research Institute | Apache 2.0 |
+| [nekomata-14b-pfn-qfin](https://arxiv.org/pdf/2404.10555)<br>([qfin](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin), [qfin-inst-merge](https://huggingface.co/pfnet/nekomata-14b-pfn-qfin-inst-merge)) | 2024 | Finance | Qwen (**14b**) | Preferred Networks | Tongyi Qianwen LICENSE |
+| [Qwen3-14B-Ja-Fin](https://arxiv.org/abs/2603.01353)<br>([CPT](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-CPT), [Thinking](https://huggingface.co/nri-ai/Qwen3-14B-Ja-Fin-Thinking)) | **2026** | Finance | Qwen3 (**14b**) | Nomura Research Institute | Apache 2.0 |
+| [Watashiha-Llama-2-13B-Ogiri-sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft/blob/main/README_en.md)<br>([sft](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft), [sft-neuron](https://huggingface.co/watashiha/Watashiha-Llama-2-13B-Ogiri-sft-neuron)) | 2024 | [Oogiri](https://en.wikipedia.org/wiki/Glossary_of_owarai_terms#oogiri)| Llama 2 (**13b**) | Watashiha | Llama 2 Community License |
+| [MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5](https://huggingface.co/IngentaAITeam/MedExamDoc-Llama-3.1-Swallow-8B-Instruct-v0.5) | 2025 | Médecine | Llama 3.1 (**8b**) | Ingenta | Llama 3.1 Community License |
+| [Karamaru](https://sakana.ai/karamaru/)<br>([Karamaru-v1](https://huggingface.co/SakanaAI/Llama-3-Karamaru-v1)) | 2025 | Edo-period Japanese | Llama 3 (**8b**) | Sakana AI | Llama 3 Community License |
+| [Llama 3.1 Future Code Ja 8B](https://huggingface.co/future-architect/Llama-3.1-Future-Code-Ja-8B) | 2025 | Codage | Llama 3.1 (**8b**) | Future Corp. | Llama 3.1 Community License |
+| [JPharmatron](https://huggingface.co/collections/EQUES/pharmatron-680a330b4dfce3ac43009984)<br>([7B-base](https://huggingface.co/EQUES/JPharmatron-7B-base), [7B](https://huggingface.co/EQUES/JPharmatron-7B)) | 2025 | Pharmaceutique | Qwen2.5 (**7b**) | EQUES Inc. | CC BY-SA 4.0 |
+| [ELYZA-japanese-CodeLlama-7b](https://note.com/elyza/n/n5bce23d7c9c8)<br>([7b](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b), [7b-instruct](https://huggingface.co/elyza/ELYZA-japanese-CodeLlama-7b-instruct)) | 2023 | Codage | Code Llama<br>(**7b**) | ELYZA | Llama 2 Community License |
+| [AIBunCho/japanese-novel-gpt-j-6b](https://huggingface.co/AIBunCho/japanese-novel-gpt-j-6b) | 2023 | Génération de récits | GPT-J (**6b**) | Individuel ([Hiroyuki Osone](https://scholar.google.co.jp/citations?user=6ID5K3oAAAAJ)) | CreativeML OpenRAIL-M License |
+| [NovelAI/genji-jp](https://huggingface.co/NovelAI/genji-jp) | 2022 | Génération de récits | GPT-J (**6b**) | NovelAI |  ？  |
 
 <a id="instruction-only-models"></a>
 ### Modèles développés à partir d'LLM non-japonais (post-entraînement uniquement, sans pré-entraînement continu ou détails inconnus)


### PR DESCRIPTION
## Summary
- #633 への対応の一環として、「海外モデルに日本語で継続事前学習を行ったモデル / ドメイン特化型」テーブル (14行) に `公開年` 列を追加
- ja/en/fr 3 言語すべて同時に更新（ヘッダー: `公開年` / `Release Year` / `Année de sortie`）
- 2026 年公開のモデルは太字
- 公開年は HuggingFace の初コミット年 (`/api/models/<repo>` の `createdAt`) を採用

## Background
#633 で「〜〜年以降のモデルのみ表示」絞り込みUIを作るにあたり、各モデル系テーブルへ年情報を順次追加していく方針。本 PR は #662 (汎用テーブル) に続く第2段。

## Test plan
- [x] `yarn docs:build` がエラーなく通ること
- [x] レンダリング後のテーブル表示確認
- [x] 同節 (継続事前学習) 内の他テーブルや前後の節に影響していないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)