### PR TITLE
LLM系の残り4テーブル (スクラッチ/ドメイン、事後学習/ドメイン、マージ、API) に公開年列を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,17 @@
 <a id="generative-scratch-domain-specific"></a>
 #### ドメイン特化型
 
-|    | ドメイン | アーキテクチャ  |  学習テキスト  |  開発元  | ライセンス |
-|:---|:---:|:---:|:---:|:---:|:---:|
-| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1) | 医療 | MoE | 医療系コーパス (**78.3B** トークン) で LLM-jp-3 MoE (8x13b) に追加事前学習、コンテキスト長を 32k に拡張、その後 Instruction Tuning | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct) | 医療 | MoE | 医療系コーパス (**78.3B** トークン) で LLM-jp-3 MoE (8x13b) に追加事前学習、コンテキスト長を 32k に拡張、その後 PMC-Patients 等を用いた Instruction Tuning | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | SIP-jmed-llm-3-8x13b-AC-32k-instruct Terms of Use[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base) | 医療 | MoE | 医療系コーパス (**78.3B** トークン) で LLM-jp-3 MoE (8x13b) に追加事前学習 | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct) | 医療 | MoE | 医療系コーパス (**44.2B** トークン) で LLM-jp-3 MoE (8x13b) に追加事前学習、その後 Instruction Tuning | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1) | 医療 | Llama | 医療系コーパス (**78.3B** トークン) で LLM-jp-3.1 (13b) に追加事前学習、コンテキスト長を 32k に拡張、その後 Instruction Tuning | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base) | 医療 | Llama | 医療系コーパス (**78.3B** トークン) で LLM-jp-3.1 (13b) に追加事前学習 | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | Apache 2.0[^25] |
-| [日本語対話Transformer](https://group.ntt/jp/topics/2021/09/30/transformer.html) | 対話 |Transformer | Twitter 上の日本語リプライのペア | NTT | [独自のライセンス](https://github.com/nttcslab/japanese-dialog-transformers/blob/main/LICENSE.md) |
-| [日本語ニュースBART](https://tech.stockmark.co.jp/blog/bart-japanese-base-news/) | ビジネス | BART ([base](https://huggingface.co/stockmark/bart-base-japanese-news)) | 日本語ビジネスニュース記事（約2,100万記事 (2.9億文)） | ストックマーク | MIT |
-| [AcademicBART](https://github.com/EhimeNLP/AcademicBART) | 学術 | BART ([base](https://huggingface.co/EhimeNLP/AcademicBART)) | CiNii の日本語論文 | 愛媛大 人工知能研究室 | Apache 2.0 |
+|    | 公開年 | ドメイン | アーキテクチャ  |  学習テキスト  |  開発元  | ライセンス |
+|:---|:---:|:---:|:---:|:---:|:---:|:---:|
+| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1) | **2026** | 医療 | MoE | 医療系コーパス (**78.3B** トークン) で LLM-jp-3 MoE (8x13b) に追加事前学習、コンテキスト長を 32k に拡張、その後 Instruction Tuning | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct) | 2025 | 医療 | MoE | 医療系コーパス (**78.3B** トークン) で LLM-jp-3 MoE (8x13b) に追加事前学習、コンテキスト長を 32k に拡張、その後 PMC-Patients 等を用いた Instruction Tuning | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | SIP-jmed-llm-3-8x13b-AC-32k-instruct Terms of Use[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base) | 2025 | 医療 | MoE | 医療系コーパス (**78.3B** トークン) で LLM-jp-3 MoE (8x13b) に追加事前学習 | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct) | 2025 | 医療 | MoE | 医療系コーパス (**44.2B** トークン) で LLM-jp-3 MoE (8x13b) に追加事前学習、その後 Instruction Tuning | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1) | **2026** | 医療 | Llama | 医療系コーパス (**78.3B** トークン) で LLM-jp-3.1 (13b) に追加事前学習、コンテキスト長を 32k に拡張、その後 Instruction Tuning | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base) | 2025 | 医療 | Llama | 医療系コーパス (**78.3B** トークン) で LLM-jp-3.1 (13b) に追加事前学習 | 戦略的イノベーション創造プログラム（SIP）第3期課題「統合型ヘルスケアシステムの構築における生成 AI 活用」テーマ1「安全性・信頼性を持つオープンな医療 LLM の開発・社会実装」 研究グループ | Apache 2.0[^25] |
+| [日本語対話Transformer](https://group.ntt/jp/topics/2021/09/30/transformer.html) | 2021 | 対話 |Transformer | Twitter 上の日本語リプライのペア | NTT | [独自のライセンス](https://github.com/nttcslab/japanese-dialog-transformers/blob/main/LICENSE.md) |
+| [日本語ニュースBART](https://tech.stockmark.co.jp/blog/bart-japanese-base-news/) | 2023 | ビジネス | BART ([base](https://huggingface.co/stockmark/bart-base-japanese-news)) | 日本語ビジネスニュース記事（約2,100万記事 (2.9億文)） | ストックマーク | MIT |
+| [AcademicBART](https://github.com/EhimeNLP/AcademicBART) | 2023 | 学術 | BART ([base](https://huggingface.co/EhimeNLP/AcademicBART)) | CiNii の日本語論文 | 愛媛大 人工知能研究室 | Apache 2.0 |
 
 <a id="english-based-models"></a>
 ### 海外モデルに日本語で継続事前学習を行ったモデル
@@ -276,32 +276,32 @@
 <a id="generative-instruction-only-domain-specific"></a>
 #### ドメイン特化型
 
-|    | ドメイン | ベースのLLM  |  開発元  | ライセンス |
-|:---|:---:|:---:|:---:|:---:|
-| [JMedLoRA](https://arxiv.org/pdf/2310.10083.pdf)<br>([llama2-jmedlora-6.89ep](https://huggingface.co/AIgroup-CVM-utokyohospital/llama2-jmedlora-6.89ep)) | 医療 | Llama 2 (**70b**) | 東京大学医学部附属病院 循環器内科 AIグループ | CC BY-NC 4.0 |
-| [pfnet/Qwen3-1.7B-pfn-qfin](https://huggingface.co/pfnet/Qwen3-1.7B-pfn-qfin) | 金融 | Qwen3 (**1.72b**) | Preferred Networks | PLaMo Community License |
-| [pfnet/Qwen2.5-1.5B-pfn-qfin](https://huggingface.co/pfnet/Qwen2.5-1.5B-pfn-qfin) | 金融 | Qwen2.5 (**1.54b**) | Preferred Networks | PLaMo Community License |
+|    | 公開年 | ドメイン | ベースのLLM  |  開発元  | ライセンス |
+|:---|:---:|:---:|:---:|:---:|:---:|
+| [JMedLoRA](https://arxiv.org/pdf/2310.10083.pdf)<br>([llama2-jmedlora-6.89ep](https://huggingface.co/AIgroup-CVM-utokyohospital/llama2-jmedlora-6.89ep)) | 2023 | 医療 | Llama 2 (**70b**) | 東京大学医学部附属病院 循環器内科 AIグループ | CC BY-NC 4.0 |
+| [pfnet/Qwen3-1.7B-pfn-qfin](https://huggingface.co/pfnet/Qwen3-1.7B-pfn-qfin) | 2025 | 金融 | Qwen3 (**1.72b**) | Preferred Networks | PLaMo Community License |
+| [pfnet/Qwen2.5-1.5B-pfn-qfin](https://huggingface.co/pfnet/Qwen2.5-1.5B-pfn-qfin) | 2025 | 金融 | Qwen2.5 (**1.54b**) | Preferred Networks | PLaMo Community License |
 
 <a id="merged-models"></a>
 ### 複数のLLMをマージして作成されたモデル
 
-|    |  マージ元のLLM（太字は日本語LLM）  | 開発元  | ライセンス |
-|:---|:---:|:---:|:---:|
- [EQUES/MedLLama3-JP-v2](https://huggingface.co/EQUES/MedLLama3-JP-v2) | **Llama 3 Swallow 8B (Instruct)**, OpenBioLLM-8B, MMed-Llama 3 8B, **Llama 3 ELYZA JP 8B** | EQUES | Llama 3 Community License |
-| [EvoLLM-JP-A](https://sakana.ai/evolutionary-model-merge-jp/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-A-v1-7B)) | **Shisa Gamma 7B (v1)**, Arithmo2 Mistral 7B, Abel 7B 002 | Sakana AI | Apache 2.0 |
-| [EvoLLM-JP](https://sakana.ai/evolutionary-model-merge-jp/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-7B), [v1-10B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-10B)) | **Shisa Gamma 7B (v1)**, WizardMath-7B-V1.1, Abel 7B 002 | Sakana AI | MICROSOFT RESEARCH LICENSE |
-| [EQUES/TinyQwens-Merge-1.5B](https://huggingface.co/EQUES/TinyQwens-Merge-1.5B) | **SakanaAI/TinySwallow-1.5B-Instruct**, **EQUES/TinySwallow-Stratos-1.5B**, deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B, Qwen/Qwen2.5-1.5B-Instruct | EQUES Inc. | Apache 2.0 |
+|    | 公開年 |  マージ元のLLM（太字は日本語LLM）  | 開発元  | ライセンス |
+|:---|:---:|:---:|:---:|:---:|
+| [EQUES/MedLLama3-JP-v2](https://huggingface.co/EQUES/MedLLama3-JP-v2) | 2024 | **Llama 3 Swallow 8B (Instruct)**, OpenBioLLM-8B, MMed-Llama 3 8B, **Llama 3 ELYZA JP 8B** | EQUES | Llama 3 Community License |
+| [EvoLLM-JP-A](https://sakana.ai/evolutionary-model-merge-jp/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-A-v1-7B)) | 2024 | **Shisa Gamma 7B (v1)**, Arithmo2 Mistral 7B, Abel 7B 002 | Sakana AI | Apache 2.0 |
+| [EvoLLM-JP](https://sakana.ai/evolutionary-model-merge-jp/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-7B), [v1-10B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-10B)) | 2024 | **Shisa Gamma 7B (v1)**, WizardMath-7B-V1.1, Abel 7B 002 | Sakana AI | MICROSOFT RESEARCH LICENSE |
+| [EQUES/TinyQwens-Merge-1.5B](https://huggingface.co/EQUES/TinyQwens-Merge-1.5B) | 2025 | **SakanaAI/TinySwallow-1.5B-Instruct**, **EQUES/TinySwallow-Stratos-1.5B**, deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B, Qwen/Qwen2.5-1.5B-Instruct | EQUES Inc. | Apache 2.0 |
 
 <a id="api-based-models"></a>
 ### APIとして提供されているモデル
 
-|    |  入出力で扱える<br>トークン数 | 開発元  |  プラットフォーム |
-|:---|:---:|:---:|:---:|
-| [PLaMo API](https://plamo.preferredai.jp/api) | 32,768 | Preferred Networks | 独自 |
-| [AIのべりすと](https://ai-novel.com/account_api.php) | 2,400 ~ 8,192 | Bit192 | 独自 |
-| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | | オルツ | AWS Marketplace (SageMaker) |
-| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 32,768 | カラクリ, Upstage | AWS Marketplace (SageMaker) |
-| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | | NTT | Microsoft Foundry |
+|    | 公開年 |  入出力で扱える<br>トークン数 | 開発元  |  プラットフォーム |
+|:---|:---:|:---:|:---:|:---:|
+| [PLaMo API](https://plamo.preferredai.jp/api) | 2024 | 32,768 | Preferred Networks | 独自 |
+| [AIのべりすと](https://ai-novel.com/account_api.php) | 2021 | 2,400 ~ 8,192 | Bit192 | 独自 |
+| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | オルツ | AWS Marketplace (SageMaker) |
+| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | カラクリ, Upstage | AWS Marketplace (SageMaker) |
+| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | 2024 | | NTT | Microsoft Foundry |
 
 <a id="autoencoding"></a>
 ## 入力テキストの処理に主に使うモデル

--- a/en/README.md
+++ b/en/README.md
@@ -97,17 +97,17 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 <a id="generative-scratch-domain-specific"></a>
 #### Domain Specific
 
-|    |  Domain  |  Architecture  |  Training Data  |  Developer  | License |
-|:---|:---:|:---:|:---:|:---:|:---:|
-| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1) | Medical | MoE | Continual pre-training on a medical corpus (**78.3B** tokens) added to LLM-jp-3 MoE (8x13b), context length extended to 32k, followed by Instruction Tuning | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct) | Medical | MoE | Continual pre-training on a medical corpus (**78.3B** tokens) added to LLM-jp-3 MoE (8x13b), context length extended to 32k, followed by Instruction Tuning using PMC-Patients and others | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | SIP-jmed-llm-3-8x13b-AC-32k-instruct Terms of Use[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base) | Medical | MoE | Continual pre-training on a medical corpus (**78.3B** tokens) added to LLM-jp-3 MoE (8x13b) | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct) | Medical | MoE | Pre-trained on a medical corpus (**44.2B** tokens) added to LLM-jp-3 MoE (8x13b), followed by Instruction Tuning | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1) | Medical | Llama | Continual pre-training on a medical corpus (**78.3B** tokens) added to LLM-jp-3.1 (13b), context length extended to 32k, followed by Instruction Tuning | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base) | Medical | Llama | Continual pre-training on a medical corpus (**78.3B** tokens) added to LLM-jp-3.1 (13b) | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | Apache 2.0[^25] |
-| [Japanese Dialog Transformer](https://github.com/nttcslab/japanese-dialog-transformers) | Dialog | Transformer | Twitter Japanese reply pairs | NTT | [Evaluation Licence](https://github.com/nttcslab/japanese-dialog-transformers/blob/main/LICENSE.md) |
-| [Japanese News BART](https://tech.stockmark.co.jp/blog/bart-japanese-base-news/) | Business |  BART ([base](https://huggingface.co/stockmark/bart-base-japanese-news)) | Japanese business news articles (21M articles) | Stockmark | MIT |
-| [AcademicBART](https://github.com/EhimeNLP/AcademicBART) | Science | BART ([base](https://huggingface.co/EhimeNLP/AcademicBART)) | CiNii Japanese Papers | Ehime University AI Lab | Apache 2.0 |
+|    | Release Year |  Domain  |  Architecture  |  Training Data  |  Developer  | License |
+|:---|:---:|:---:|:---:|:---:|:---:|:---:|
+| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1) | **2026** | Medical | MoE | Continual pre-training on a medical corpus (**78.3B** tokens) added to LLM-jp-3 MoE (8x13b), context length extended to 32k, followed by Instruction Tuning | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct) | 2025 | Medical | MoE | Continual pre-training on a medical corpus (**78.3B** tokens) added to LLM-jp-3 MoE (8x13b), context length extended to 32k, followed by Instruction Tuning using PMC-Patients and others | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | SIP-jmed-llm-3-8x13b-AC-32k-instruct Terms of Use[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base) | 2025 | Medical | MoE | Continual pre-training on a medical corpus (**78.3B** tokens) added to LLM-jp-3 MoE (8x13b) | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct) | 2025 | Medical | MoE | Pre-trained on a medical corpus (**44.2B** tokens) added to LLM-jp-3 MoE (8x13b), followed by Instruction Tuning | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1) | **2026** | Medical | Llama | Continual pre-training on a medical corpus (**78.3B** tokens) added to LLM-jp-3.1 (13b), context length extended to 32k, followed by Instruction Tuning | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base) | 2025 | Medical | Llama | Continual pre-training on a medical corpus (**78.3B** tokens) added to LLM-jp-3.1 (13b) | Strategic Innovation Promotion Program (SIP) Phase 3 Project "Generative AI Utilization in the Construction of Integrated Healthcare Systems" Theme 1 "Development and Social Implementation of Open Medical LLM with Safety and Reliability" Research Group | Apache 2.0[^25] |
+| [Japanese Dialog Transformer](https://github.com/nttcslab/japanese-dialog-transformers) | 2021 | Dialog | Transformer | Twitter Japanese reply pairs | NTT | [Evaluation Licence](https://github.com/nttcslab/japanese-dialog-transformers/blob/main/LICENSE.md) |
+| [Japanese News BART](https://tech.stockmark.co.jp/blog/bart-japanese-base-news/) | 2023 | Business |  BART ([base](https://huggingface.co/stockmark/bart-base-japanese-news)) | Japanese business news articles (21M articles) | Stockmark | MIT |
+| [AcademicBART](https://github.com/EhimeNLP/AcademicBART) | 2023 | Science | BART ([base](https://huggingface.co/EhimeNLP/AcademicBART)) | CiNii Japanese Papers | Ehime University AI Lab | Apache 2.0 |
 
 <a id="english-based-models"></a>
 ### Models built off non-Japanese LLMs (w/ continual pre-training on Japanese)
@@ -276,32 +276,32 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 <a id="generative-instruction-only-domain-specific"></a>
 #### Domain specific
 
-|    | Domain | Base Model  |  Developer  |  License  |
-|:---|:---:|:---:|:---:|:---:|
-| [JMedLoRA](https://arxiv.org/pdf/2310.10083.pdf)<br>([llama2-jmedlora-6.89ep](https://huggingface.co/AIgroup-CVM-utokyohospital/llama2-jmedlora-6.89ep)) | Medicine | Llama 2 (**70b**) | University of Tokyo Hospital Department of Cardiovascular Medicine AI Group | CC BY-NC 4.0 |
-| [pfnet/Qwen3-1.7B-pfn-qfin](https://huggingface.co/pfnet/Qwen3-1.7B-pfn-qfin) | Finance | Qwen3 (**1.72b**) | Preferred Networks | PLaMo Community License |
-| [pfnet/Qwen2.5-1.5B-pfn-qfin](https://huggingface.co/pfnet/Qwen2.5-1.5B-pfn-qfin) | Finance | Qwen2.5 (**1.54b**) | Preferred Networks | PLaMo Community License |
+|    | Release Year | Domain | Base Model  |  Developer  |  License  |
+|:---|:---:|:---:|:---:|:---:|:---:|
+| [JMedLoRA](https://arxiv.org/pdf/2310.10083.pdf)<br>([llama2-jmedlora-6.89ep](https://huggingface.co/AIgroup-CVM-utokyohospital/llama2-jmedlora-6.89ep)) | 2023 | Medicine | Llama 2 (**70b**) | University of Tokyo Hospital Department of Cardiovascular Medicine AI Group | CC BY-NC 4.0 |
+| [pfnet/Qwen3-1.7B-pfn-qfin](https://huggingface.co/pfnet/Qwen3-1.7B-pfn-qfin) | 2025 | Finance | Qwen3 (**1.72b**) | Preferred Networks | PLaMo Community License |
+| [pfnet/Qwen2.5-1.5B-pfn-qfin](https://huggingface.co/pfnet/Qwen2.5-1.5B-pfn-qfin) | 2025 | Finance | Qwen2.5 (**1.54b**) | Preferred Networks | PLaMo Community License |
 
 <a id="merged-models"></a>
 ### Merged models
 
-|    |  Original Models (Japanese LLMs in bold)  | Developer  |  License  |
-|:---|:---:|:---:|:---:|
- [EQUES/MedLLama3-JP-v2](https://huggingface.co/EQUES/MedLLama3-JP-v2) | **Llama 3 Swallow 8B (Instruct)**, OpenBioLLM-8B, MMed-Llama 3 8B, **Llama 3 ELYZA JP 8B** | EQUES | Llama 3 Community License |
-| [EvoLLM-JP-A](https://sakana.ai/evolutionary-model-merge/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-A-v1-7B)) | **Shisa Gamma 7B (v1)**, Arithmo2 Mistral 7B, Abel 7B 002 | Sakana AI | Apache 2.0 |
-| [EvoLLM-JP](https://sakana.ai/evolutionary-model-merge/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-7B), [v1-10B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-10B)) | **Shisa Gamma 7B (v1)**, WizardMath-7B-V1.1, Abel 7B 002 | Sakana AI | MICROSOFT RESEARCH LICENSE |
-| [EQUES/TinyQwens-Merge-1.5B](https://huggingface.co/EQUES/TinyQwens-Merge-1.5B) | **SakanaAI/TinySwallow-1.5B-Instruct**, **EQUES/TinySwallow-Stratos-1.5B**, deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B, Qwen/Qwen2.5-1.5B-Instruct | EQUES Inc. | Apache 2.0 |
+|    | Release Year |  Original Models (Japanese LLMs in bold)  | Developer  |  License  |
+|:---|:---:|:---:|:---:|:---:|
+| [EQUES/MedLLama3-JP-v2](https://huggingface.co/EQUES/MedLLama3-JP-v2) | 2024 | **Llama 3 Swallow 8B (Instruct)**, OpenBioLLM-8B, MMed-Llama 3 8B, **Llama 3 ELYZA JP 8B** | EQUES | Llama 3 Community License |
+| [EvoLLM-JP-A](https://sakana.ai/evolutionary-model-merge/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-A-v1-7B)) | 2024 | **Shisa Gamma 7B (v1)**, Arithmo2 Mistral 7B, Abel 7B 002 | Sakana AI | Apache 2.0 |
+| [EvoLLM-JP](https://sakana.ai/evolutionary-model-merge/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-7B), [v1-10B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-10B)) | 2024 | **Shisa Gamma 7B (v1)**, WizardMath-7B-V1.1, Abel 7B 002 | Sakana AI | MICROSOFT RESEARCH LICENSE |
+| [EQUES/TinyQwens-Merge-1.5B](https://huggingface.co/EQUES/TinyQwens-Merge-1.5B) | 2025 | **SakanaAI/TinySwallow-1.5B-Instruct**, **EQUES/TinySwallow-Stratos-1.5B**, deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B, Qwen/Qwen2.5-1.5B-Instruct | EQUES Inc. | Apache 2.0 |
 
 <a id="api-based-models"></a>
 ### API-based models
 
-|    |  Max Context Length | Developer  | Platform |
-|:---|:---:|:---:|:---:|
-| [PLaMo API](https://plamo.preferredai.jp/api) | 32,768 | Preferred Networks | self-owned |
-| [AI Novelist](https://ai-novel.com/account_api.php) | 2,400 ~ 8,192 | Bit192 | self-owned |
-| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | | alt Inc. | AWS Marketplace (SageMaker) |
-| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 32,768 | KARAKURI, Upstage | AWS Marketplace (SageMaker) |
-| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | | NTT | Microsoft Foundry |
+|    | Release Year |  Max Context Length | Developer  | Platform |
+|:---|:---:|:---:|:---:|:---:|
+| [PLaMo API](https://plamo.preferredai.jp/api) | 2024 | 32,768 | Preferred Networks | self-owned |
+| [AI Novelist](https://ai-novel.com/account_api.php) | 2021 | 2,400 ~ 8,192 | Bit192 | self-owned |
+| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | alt Inc. | AWS Marketplace (SageMaker) |
+| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | KARAKURI, Upstage | AWS Marketplace (SageMaker) |
+| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | 2024 | | NTT | Microsoft Foundry |
 
 <a id="autoencoding"></a>
 ## Encoder models

--- a/fr/README.md
+++ b/fr/README.md
@@ -97,17 +97,17 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 <a id="generative-scratch-domain-specific"></a>
 #### Spécifique à un domaine
 
-|    | Domaine | Architecture  |  Données d'entraînement  |  Développeur  | Licence |
-|:---|:---:|:---:|:---:|:---:|:---:|
-| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1) | Médical | MoE | Pré-entraînement continu sur un corpus médical (**78,3 milliards** de tokens) ajouté à LLM-jp-3 MoE (8x13b), longueur de contexte étendue à 32k, suivi d'un ajustement fin par instructions | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct) | Médical | MoE | Pré-entraînement continu sur un corpus médical (**78,3 milliards** de tokens) ajouté à LLM-jp-3 MoE (8x13b), longueur de contexte étendue à 32k, suivi d'un ajustement fin par instructions utilisant PMC-Patients et d'autres jeux de données | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | SIP-jmed-llm-3-8x13b-AC-32k-instruct Terms of Use[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base) | Médical | MoE | Pré-entraînement continu sur un corpus médical (**78,3 milliards** de tokens) ajouté à LLM-jp-3 MoE (8x13b) | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct) | Médical | MoE | Pré-entraîné sur un corpus médical (**44,2 milliards** de tokens) ajouté à LLM-jp-3 MoE (8x13b), suivi d'un ajustement fin par instructions | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1) | Médical | Llama | Pré-entraînement continu sur un corpus médical (**78,3 milliards** de tokens) ajouté à LLM-jp-3.1 (13b), longueur de contexte étendue à 32k, suivi d'un ajustement fin par instructions | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | Apache 2.0[^25] |
-| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base) | Médical | Llama | Pré-entraînement continu sur un corpus médical (**78,3 milliards** de tokens) ajouté à LLM-jp-3.1 (13b) | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | Apache 2.0[^25] |
-| [Japanese Dialog Transformer](https://github.com/nttcslab/japanese-dialog-transformers) | Dialogue | Transformer | Pairs de réponses venant de Twitter | NTT | [Licence en évaluation](https://github.com/nttcslab/japanese-dialog-transformers/blob/main/LICENSE.md) |
-| [Japanese News BART](https://tech.stockmark.co.jp/blog/bart-japanese-base-news/) | Affaires |  BART ([base](https://huggingface.co/stockmark/bart-base-japanese-news)) | Articles de l'actualité économique en japonais (21M articles) | Stockmark | MIT |
-| [AcademicBART](https://github.com/EhimeNLP/AcademicBART) | Science | BART ([base](https://huggingface.co/EhimeNLP/AcademicBART)) | Articles japonais de CiNii | Laboratoire d'IA de l'Université d'Ehime | Apache 2.0 |
+|    | Année de sortie | Domaine | Architecture  |  Données d'entraînement  |  Développeur  | Licence |
+|:---|:---:|:---:|:---:|:---:|:---:|:---:|
+| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-32k-R0.1) | **2026** | Médical | MoE | Pré-entraînement continu sur un corpus médical (**78,3 milliards** de tokens) ajouté à LLM-jp-3 MoE (8x13b), longueur de contexte étendue à 32k, suivi d'un ajustement fin par instructions | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-AC-32k-instruct) | 2025 | Médical | MoE | Pré-entraînement continu sur un corpus médical (**78,3 milliards** de tokens) ajouté à LLM-jp-3 MoE (8x13b), longueur de contexte étendue à 32k, suivi d'un ajustement fin par instructions utilisant PMC-Patients et d'autres jeux de données | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | SIP-jmed-llm-3-8x13b-AC-32k-instruct Terms of Use[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-8x13b-OP-4k-base) | 2025 | Médical | MoE | Pré-entraînement continu sur un corpus médical (**78,3 milliards** de tokens) ajouté à LLM-jp-3 MoE (8x13b) | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-2-8x13b-OP-instruct) | 2025 | Médical | MoE | Pré-entraîné sur un corpus médical (**44,2 milliards** de tokens) ajouté à LLM-jp-3 MoE (8x13b), suivi d'un ajustement fin par instructions | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-32k-R0.1) | **2026** | Médical | Llama | Pré-entraînement continu sur un corpus médical (**78,3 milliards** de tokens) ajouté à LLM-jp-3.1 (13b), longueur de contexte étendue à 32k, suivi d'un ajustement fin par instructions | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | Apache 2.0[^25] |
+| [SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base](https://huggingface.co/SIP-med-LLM/SIP-jmed-llm-3-13b-OP-4k-base) | 2025 | Médical | Llama | Pré-entraînement continu sur un corpus médical (**78,3 milliards** de tokens) ajouté à LLM-jp-3.1 (13b) | Groupe de recherche du Programme stratégique d'innovation (SIP), Projet de phase 3 « Utilisation de l'IA générative dans la construction de systèmes de santé intégrés », Thème 1 « Développement et implémentation sociale d'un LLM médical ouvert, sûr et fiable » | Apache 2.0[^25] |
+| [Japanese Dialog Transformer](https://github.com/nttcslab/japanese-dialog-transformers) | 2021 | Dialogue | Transformer | Pairs de réponses venant de Twitter | NTT | [Licence en évaluation](https://github.com/nttcslab/japanese-dialog-transformers/blob/main/LICENSE.md) |
+| [Japanese News BART](https://tech.stockmark.co.jp/blog/bart-japanese-base-news/) | 2023 | Affaires |  BART ([base](https://huggingface.co/stockmark/bart-base-japanese-news)) | Articles de l'actualité économique en japonais (21M articles) | Stockmark | MIT |
+| [AcademicBART](https://github.com/EhimeNLP/AcademicBART) | 2023 | Science | BART ([base](https://huggingface.co/EhimeNLP/AcademicBART)) | Articles japonais de CiNii | Laboratoire d'IA de l'Université d'Ehime | Apache 2.0 |
 
 <a id="english-based-models"></a>
 ### Modèles développés à partir d'LLM non-japonais (avec un apprentissage en continue en japonais)
@@ -276,32 +276,32 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 <a id="generative-instruction-only-domain-specific"></a>
 #### Spécifique à un domaine
 
-|    | Domaine | Base du Model  |  Développeur  |  Licence  |
-|:---|:---:|:---:|:---:|:---:|
-| [JMedLoRA](https://arxiv.org/pdf/2310.10083.pdf)<br>([llama2-jmedlora-6.89ep](https://huggingface.co/AIgroup-CVM-utokyohospital/llama2-jmedlora-6.89ep)) | Médecine | Llama 2 (**70b**) | Université de Tokyo - AI Group du Département hospitalier de médecine cardiovasculaire | CC BY-NC 4.0 |
-| [pfnet/Qwen3-1.7B-pfn-qfin](https://huggingface.co/pfnet/Qwen3-1.7B-pfn-qfin) | Finance | Qwen3 (**1.72b**) | Preferred Networks | PLaMo Community License |
-| [pfnet/Qwen2.5-1.5B-pfn-qfin](https://huggingface.co/pfnet/Qwen2.5-1.5B-pfn-qfin) | Finance | Qwen2.5 (**1.54b**) | Preferred Networks | PLaMo Community License |
+|    | Année de sortie | Domaine | Base du Model  |  Développeur  |  Licence  |
+|:---|:---:|:---:|:---:|:---:|:---:|
+| [JMedLoRA](https://arxiv.org/pdf/2310.10083.pdf)<br>([llama2-jmedlora-6.89ep](https://huggingface.co/AIgroup-CVM-utokyohospital/llama2-jmedlora-6.89ep)) | 2023 | Médecine | Llama 2 (**70b**) | Université de Tokyo - AI Group du Département hospitalier de médecine cardiovasculaire | CC BY-NC 4.0 |
+| [pfnet/Qwen3-1.7B-pfn-qfin](https://huggingface.co/pfnet/Qwen3-1.7B-pfn-qfin) | 2025 | Finance | Qwen3 (**1.72b**) | Preferred Networks | PLaMo Community License |
+| [pfnet/Qwen2.5-1.5B-pfn-qfin](https://huggingface.co/pfnet/Qwen2.5-1.5B-pfn-qfin) | 2025 | Finance | Qwen2.5 (**1.54b**) | Preferred Networks | PLaMo Community License |
 
 <a id="merged-models"></a>
 ### Modèles fusionnés
 
-|    |  Modèles originaux (LLMs japonais en gras)  | Développeur  | Licence |
-|:---|:---:|:---:|:---:|
- [EQUES/MedLLama3-JP-v2](https://huggingface.co/EQUES/MedLLama3-JP-v2) | **Llama 3 Swallow 8B (Instruct)**, OpenBioLLM-8B, MMed-Llama 3 8B, **Llama 3 ELYZA JP 8B** | EQUES | Llama 3 Community License |
-| [EvoLLM-JP-A](https://sakana.ai/evolutionary-model-merge/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-A-v1-7B)) | **Shisa Gamma 7B (v1)**, Arithmo2 Mistral 7B, Abel 7B 002 | Sakana AI | Apache 2.0 |
-| [EvoLLM-JP](https://sakana.ai/evolutionary-model-merge/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-7B), [v1-10B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-10B)) | **Shisa Gamma 7B (v1)**, WizardMath-7B-V1.1, Abel 7B 002 | Sakana AI | MICROSOFT RESEARCH LICENSE |
-| [EQUES/TinyQwens-Merge-1.5B](https://huggingface.co/EQUES/TinyQwens-Merge-1.5B) | **SakanaAI/TinySwallow-1.5B-Instruct**, **EQUES/TinySwallow-Stratos-1.5B**, deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B, Qwen/Qwen2.5-1.5B-Instruct | EQUES Inc. | Apache 2.0 |
+|    | Année de sortie |  Modèles originaux (LLMs japonais en gras)  | Développeur  | Licence |
+|:---|:---:|:---:|:---:|:---:|
+| [EQUES/MedLLama3-JP-v2](https://huggingface.co/EQUES/MedLLama3-JP-v2) | 2024 | **Llama 3 Swallow 8B (Instruct)**, OpenBioLLM-8B, MMed-Llama 3 8B, **Llama 3 ELYZA JP 8B** | EQUES | Llama 3 Community License |
+| [EvoLLM-JP-A](https://sakana.ai/evolutionary-model-merge/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-A-v1-7B)) | 2024 | **Shisa Gamma 7B (v1)**, Arithmo2 Mistral 7B, Abel 7B 002 | Sakana AI | Apache 2.0 |
+| [EvoLLM-JP](https://sakana.ai/evolutionary-model-merge/)<br>([v1-7B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-7B), [v1-10B](https://huggingface.co/SakanaAI/EvoLLM-JP-v1-10B)) | 2024 | **Shisa Gamma 7B (v1)**, WizardMath-7B-V1.1, Abel 7B 002 | Sakana AI | MICROSOFT RESEARCH LICENSE |
+| [EQUES/TinyQwens-Merge-1.5B](https://huggingface.co/EQUES/TinyQwens-Merge-1.5B) | 2025 | **SakanaAI/TinySwallow-1.5B-Instruct**, **EQUES/TinySwallow-Stratos-1.5B**, deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B, Qwen/Qwen2.5-1.5B-Instruct | EQUES Inc. | Apache 2.0 |
 
 <a id="api-based-models"></a>
 ### Modèles basés sur des API
 
-|    |  Longueur Maximale du Contexte | Développeur  | Plateforme |
-|:---|:---:|:---:|:---:|
-| [PLaMo API](https://plamo.preferredai.jp/api) | 32,768 | Preferred Networks | self-owned |
-| [AI Novelist](https://ai-novel.com/account_api.php) | 2,400 ~ 8,192 | Bit192 | self-owned |
-| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | | alt Inc. | AWS Marketplace (SageMaker) |
-| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 32,768 | KARAKURI, Upstage | AWS Marketplace (SageMaker) |
-| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | | NTT | Microsoft Foundry |
+|    | Année de sortie |  Longueur Maximale du Contexte | Développeur  | Plateforme |
+|:---|:---:|:---:|:---:|:---:|
+| [PLaMo API](https://plamo.preferredai.jp/api) | 2024 | 32,768 | Preferred Networks | self-owned |
+| [AI Novelist](https://ai-novel.com/account_api.php) | 2021 | 2,400 ~ 8,192 | Bit192 | self-owned |
+| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | alt Inc. | AWS Marketplace (SageMaker) |
+| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | KARAKURI, Upstage | AWS Marketplace (SageMaker) |
+| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | 2024 | | NTT | Microsoft Foundry |
 
 <a id="autoencoding"></a>
 ## Modèles encodeur


### PR DESCRIPTION
## Summary
#633 への対応の一環として、LLM セクション内のまだ `公開年` が無かった以下4テーブルに列を追加:

| テーブル | 行数 | 備考 |
|---|---:|---|
| スクラッチ学習モデル / ドメイン特化型 | 9 | SIP-jmed-llm シリーズの新規 2026 年モデル 2 件を太字 |
| 海外モデルに日本語で事後学習を行ったモデル / ドメイン特化型 | 3 | |
| 複数のLLMをマージして作成されたモデル | 4 | |
| APIとして提供されているモデル | 5 | |

ja/en/fr 3 言語すべて同時に更新（ヘッダー: `公開年` / `Release Year` / `Année de sortie`）。

## 公開年の出典
- **HuggingFace 配布モデル**: HF API (`/api/models/<repo>`) の `createdAt` 年を採用
- **API系**: 提供開始/ローンチ発表日を採用
  - PLaMo API: 2024-12-02 (PLaMo Prime 提供開始) → 2024
  - LHTM-OPT: 2024-03 (AWS Marketplace 公開) → 2024
  - Syn: 2025-03-25 → 2025
  - tsuzumi: 2024-11-20 → 2024
  - **AIのべりすと**: API そのもののリリース日が公式に明示されていないため、サービス本体のリリース年 (2021) を採用
- **その他**: 日本語対話Transformer は NTT 発表 URL (2021/09/30) より 2021

## 副次的な修正
- マージテーブル先頭行 (EQUES/MedLLama3-JP-v2) で行頭の `|` が欠落していたのを修正

## Test plan
- [x] `yarn docs:build` がエラーなく通ること
- [x] レンダリング後のテーブル表示確認
- [x] 同節 (継続事前学習以外) 内の他テーブルや前後の節に影響していないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)