### PR TITLE
Jagle-VL 2.2B を追加

### DIFF
--- a/.claude/rules/table-formatting.md
+++ b/.claude/rules/table-formatting.md
@@ -14,6 +14,14 @@ paths:
 - **Release year bolding**: The latest/newest release year (e.g., the current year) should be **bolded** in the table. When the year is no longer the newest, the bold is removed (see commit history for precedent).
 - **Developer column for individuals**: When the developer is an individual (not a company/university/research lab), use the format `個人 (name)` (JA) / `Individual (name)` (EN) / `Individuel (name)` (FR). Do NOT write the HuggingFace username alone.
 
+# Cell Content Formatting
+
+- **Do NOT use bullet-style lists inside table cells.** Avoid leading-hyphen pseudo-lists like `-項目A: 内容<br>-項目B: 内容<br>-項目C: 内容` — these read as Markdown bullets and clutter the table.
+- **Preferred patterns for multi-item content within a cell:**
+  - **`Label: content<br>Label: content`** — colon-delimited labels without a leading hyphen (e.g., `事前学習: ...<br>Instruction Tuning: ...<br>DPO (instruct3 only): ...`). The label is a training phase, method, or qualifier — not a model variant name.
+  - **Prose** — when distinguishing among model variants in the same row (e.g., `-Jagle` / `-FineVision` suffixes), describe the distinction in a single sentence with parenthetical qualifiers, not stacked bullets.
+- `<br>` itself is fine for line breaks; the rule is specifically about avoiding `-` at line starts and avoiding repeated label-style rows that mimic bullet lists for model variants.
+
 # Multilingual Consistency
 
 - Update all three files (README.md, en/README.md, fr/README.md) simultaneously

--- a/.claude/rules/vlm-addition.md
+++ b/.claude/rules/vlm-addition.md
@@ -13,11 +13,15 @@ Classify each model independently based on its own training approach. Do NOT ass
 
 | Section | Criteria |
 |---------|----------|
-| スクラッチ学習モデル | New VLM built from scratch, typically combining a Japanese LLM + vision encoder with substantial multi-stage training |
-| 海外モデルに日本語で追加学習 | Fine-tuned from an existing foreign VLM (e.g., Qwen-VL, InternVL). If the base model is a foreign VLM, it belongs here regardless of training scale |
+| スクラッチ学習モデル | New VLM assembled from an LLM + vision encoder (+ projector) — i.e., a VLM that did not previously exist. The LLM may be Japanese (e.g., LLM-jp, PLaMo, Sarashina) OR foreign (e.g., Phi-4, Qwen3-1.7B); what matters is that the **VLM itself is new**, not pre-existing. Multi-stage training is typical but not required. |
+| 海外モデルに日本語で追加学習 | Fine-tuned from an existing foreign VLM (e.g., Qwen2.5-VL, Qwen3-VL, InternVL). If the base model is already a foreign VLM, it belongs here regardless of training scale. |
 | マージモデル | VLMs created by merging techniques |
 
 **Critical Rule:** Always check the base model. If a model is fine-tuned from a foreign VLM (e.g., `Qwen3-VL-8B-Thinking`), it belongs in 「海外モデルに日本語で追加学習」, even if other models from the same developer are in a different section.
+
+**Distinguishing scratch vs. foreign-fine-tuned (common source of confusion):**
+- Base is a **foreign LLM** (text-only, e.g., Qwen3-1.7B, Phi-4) + vision encoder newly attached → **スクラッチ学習モデル** (the VLM is new, even if the LLM is foreign). Precedents: NABLA-VL (Phi-4 + SigLIP), Jagle-VL (Qwen3-1.7B + SigLIP2), LLM-jp-4-VL (LLM-jp-4 + SigLIP2).
+- Base is a **foreign VLM** (already vision-capable, e.g., Qwen2.5-VL, Qwen3-VL, InternVL2) → **海外モデルに日本語で追加学習**. Precedents: KARAKURI VL 2 (Qwen3-VL-8B), Stockmark-DocReasoner (Qwen2.5-VL-32B).
 
 **How to identify the base model:** Use the HuggingFace **Model tree** (right sidebar) — this is the structured ground truth. Do NOT rely solely on model card prose like "○○および△△をもとに開発" / "based on A and B", which often lists multiple models for acknowledgment even when only one is the technical base. See `model-addition.md` for the full verification checklist.
 

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@
 
 #### スクラッチ学習モデル
 
+※LLMと視覚エンコーダを組み合わせて新規に構築されたVLMが該当します (ベースのLLMは国内モデル/海外モデルを問いません)
+
 ##### 汎用
 
 |    | 公開年 |  アーキテクチャ |  学習画像/テキスト  |  開発元  | ライセンス / 利用規約 |
@@ -439,6 +441,7 @@
 | [Japanese InstructBLIP Alpha](https://huggingface.co/stabilityai/japanese-instructblip-alpha)<br>([japanese-instructblip-alpha](https://huggingface.co/stabilityai/japanese-instructblip-alpha)) | 2023 | InstructBLIP | Japanese CC12M, STAIR Captions, Japanese Visual Genome VQA dataset | Stability AI | JAPANESE STABLELM RESEARCH LICENSE |
 | [rinna MiniGPT-4](https://huggingface.co/rinna/bilingual-gpt-neox-4b-minigpt4)<br>([bilingual-gpt-neox-4b-minigpt4](https://huggingface.co/rinna/bilingual-gpt-neox-4b-minigpt4)) | 2023 | MiniGPT-4 | CC12M, COCO 2014, Visual Genome, STAIR Captions, Japanese Visual Genome VQA dataset | rinna | MIT |
 | [Sarashina2.2-Vision-3B](https://www.sbintuitions.co.jp/blog/entry/2025/11/25/100000)<br>([**3.8b**](https://huggingface.co/sbintuitions/sarashina2.2-vision-3b)) | 2025 | Sarashina2.2-3B-Instruct + SigLIP + 2-layer MLP | 4段階学習 + Post-training: プロジェクターウォームアップ (英語画像キャプション)、視覚エンコーダー事前学習 (日本語チャート、OCR、キャプション)、全モデル事前学習 (画像テキストインターリーブデータ)、教師ありファインチューニング<br>Post-training: Mixed Preference Optimization<br>(計 日本語103B + 英語157.1B トークン) | SB Intuitions | MIT |
+| [Jagle-VL 2.2B](https://arxiv.org/abs/2604.02048)<br>([**2.2b**-Jagle](https://huggingface.co/llm-jp/Jagle-VL-2.2B-Jagle), [**2.2b**-FineVision](https://huggingface.co/llm-jp/Jagle-VL-2.2B-FineVision), [**2.2b**-Jagle-FineVision](https://huggingface.co/llm-jp/Jagle-VL-2.2B-Jagle-FineVision)) | **2026** | InternVL3 (Qwen3-1.7B + siglip2-so400m-patch16-512 + 2層MLP) | [Jagle](https://huggingface.co/datasets/llm-jp/Jagle) (約920万事例の大規模日本語マルチモーダル事後学習データセット) および FineVision を用いて学習 (モデル名末尾の `-Jagle` / `-FineVision` / `-Jagle-FineVision` が使用データの組み合わせに対応) | 大規模言語モデル研究開発センター | Apache 2.0 |
 | [PLaMo 2.1 2B VL](https://tech.preferred.jp/ja/blog/plamo21_8b_vl_part2/)<br>([**2b**-vl](https://huggingface.co/pfnet/plamo-2.1-2b-vl)) | **2026** | LLaVA (PLaMo 2.1-2B + siglip2-so400m-patch14-384 + MLP) | 2段階学習: Stage 1.0: 画像アダプタの学習 (日:英=75:25 のWeb規模画像キャプションデータ)、Stage 1.5: LoRA による Instruction Tuning と日本語視覚適応 (VQA、Visual Grounding、オブジェクト検出、異常検出、工場作業理解データ) | Preferred Networks | PLaMo community license |
 
 ##### ドメイン特化型

--- a/en/README.md
+++ b/en/README.md
@@ -419,6 +419,8 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 
 #### Models built from scratch
 
+*Includes VLMs newly built by combining an LLM with a vision encoder (the base LLM can be either domestic or non-Japanese).
+
 ##### General purpose
 
 |    | Year |  Architecture  |  Training Data  |  Developer  | License / Terms of Use |
@@ -439,6 +441,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 | [Japanese InstructBLIP Alpha](https://huggingface.co/stabilityai/japanese-instructblip-alpha)<br>([japanese-instructblip-alpha](https://huggingface.co/stabilityai/japanese-instructblip-alpha)) | 2023 | InstructBLIP | Japanese CC12M, STAIR Captions, Japanese Visual Genome VQA dataset | Stability AI | JAPANESE STABLELM RESEARCH LICENSE |
 | [rinna MiniGPT-4](https://huggingface.co/rinna/bilingual-gpt-neox-4b)<br>([bilingual-gpt-neox-4b-minigpt4](https://huggingface.co/rinna/bilingual-gpt-neox-4b-minigpt4)) | 2023 | MiniGPT-4 | CC12M, COCO 2014, Visual Genome, STAIR Captions, Japanese Visual Genome VQA dataset | rinna | MIT |
 | [Sarashina2.2-Vision-3B](https://www.sbintuitions.co.jp/blog/entry/2025/11/25/100000)<br>([**3.8b**](https://huggingface.co/sbintuitions/sarashina2.2-vision-3b)) | 2025 | Sarashina2.2-3B-Instruct + SigLIP + 2-layer MLP | 4-stage training + Post-training: Projector warmup (English image captions), Vision encoder pre-training (Japanese charts, OCR, captions), Full model pre-training (interleaved image-text data), Supervised fine-tuning<br>Post-training: Mixed Preference Optimization<br>(Total: 103B Japanese + 157.1B English tokens) | SB Intuitions | MIT |
+| [Jagle-VL 2.2B](https://arxiv.org/abs/2604.02048)<br>([**2.2b**-Jagle](https://huggingface.co/llm-jp/Jagle-VL-2.2B-Jagle), [**2.2b**-FineVision](https://huggingface.co/llm-jp/Jagle-VL-2.2B-FineVision), [**2.2b**-Jagle-FineVision](https://huggingface.co/llm-jp/Jagle-VL-2.2B-Jagle-FineVision)) | **2026** | InternVL3 (Qwen3-1.7B + siglip2-so400m-patch16-512 + 2-layer MLP) | Trained on [Jagle](https://huggingface.co/datasets/llm-jp/Jagle) (large-scale Japanese multimodal post-training dataset, ~9.2M samples) and FineVision (model name suffixes `-Jagle` / `-FineVision` / `-Jagle-FineVision` indicate which combination is used) | Research and Development Center for Large Language Models | Apache 2.0 |
 | [PLaMo 2.1 2B VL](https://tech.preferred.jp/ja/blog/plamo21_8b_vl_part2/)<br>([**2b**-vl](https://huggingface.co/pfnet/plamo-2.1-2b-vl)) | **2026** | LLaVA (PLaMo 2.1-2B + siglip2-so400m-patch14-384 + MLP) | 2-stage training: Stage 1.0: Image adapter training (web-scale image-caption data with Japanese:English = 75:25), Stage 1.5: Instruction Tuning and Japanese visual adaptation via LoRA (VQA, Visual Grounding, object detection, anomaly detection, factory work understanding) | Preferred Networks | PLaMo community license |
 
 ##### Domain Specific

--- a/fr/README.md
+++ b/fr/README.md
@@ -419,6 +419,8 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 
 #### Modèles développés à partir de zéro
 
+*Inclut les VLM nouvellement construits en combinant un LLM avec un encodeur de vision (le LLM de base peut être japonais ou non-japonais).
+
 ##### D'usage général
 
 |    | Année |  Architecture |  Données d'entraînement  |  Développeur  | License / Terms of Use |
@@ -439,6 +441,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 | [Japanese InstructBLIP Alpha](https://huggingface.co/stabilityai/japanese-instructblip-alpha)<br>([japanese-instructblip-alpha](https://huggingface.co/stabilityai/japanese-instructblip-alpha)) | 2023 | InstructBLIP | Japanese CC12M, STAIR Captions, jeu de données Japanese Visual Genome VQA | Stability AI | JAPANESE STABLELM RESEARCH LICENSE |
 | [rinna MiniGPT-4](https://huggingface.co/rinna/bilingual-gpt-neox-4b)<br>([bilingual-gpt-neox-4b-minigpt4](https://huggingface.co/rinna/bilingual-gpt-neox-4b-minigpt4)) | 2023 | MiniGPT-4 | CC12M, COCO 2014, Visual Genome, STAIR Captions, Japanese Visual Genome VQA dataset | rinna | MIT |
 | [Sarashina2.2-Vision-3B](https://www.sbintuitions.co.jp/blog/entry/2025/11/25/100000)<br>([**3.8b**](https://huggingface.co/sbintuitions/sarashina2.2-vision-3b)) | 2025 | Sarashina2.2-3B-Instruct + SigLIP + 2-layer MLP | Entraînement en 4 étapes + Post-entraînement: Échauffement du projecteur (légendes d'images anglaises), Pré-entraînement de l'encodeur de vision (graphiques japonais, OCR, légendes), Pré-entraînement du modèle complet (données entrelacées image-texte), Affinement supervisé<br>Post-entraînement: Optimisation de préférences mixtes<br>(Total: 103B japonais + 157.1B tokens anglais) | SB Intuitions | MIT |
+| [Jagle-VL 2.2B](https://arxiv.org/abs/2604.02048)<br>([**2.2b**-Jagle](https://huggingface.co/llm-jp/Jagle-VL-2.2B-Jagle), [**2.2b**-FineVision](https://huggingface.co/llm-jp/Jagle-VL-2.2B-FineVision), [**2.2b**-Jagle-FineVision](https://huggingface.co/llm-jp/Jagle-VL-2.2B-Jagle-FineVision)) | **2026** | InternVL3 (Qwen3-1.7B + siglip2-so400m-patch16-512 + MLP à 2 couches) | Entraîné sur [Jagle](https://huggingface.co/datasets/llm-jp/Jagle) (jeu de données de post-entraînement multimodal japonais à grande échelle, ~9,2M échantillons) et FineVision (les suffixes `-Jagle` / `-FineVision` / `-Jagle-FineVision` du nom du modèle indiquent quelle combinaison est utilisée) | Research and Development Center for Large Language Models | Apache 2.0 |
 | [PLaMo 2.1 2B VL](https://tech.preferred.jp/ja/blog/plamo21_8b_vl_part2/)<br>([**2b**-vl](https://huggingface.co/pfnet/plamo-2.1-2b-vl)) | **2026** | LLaVA (PLaMo 2.1-2B + siglip2-so400m-patch14-384 + MLP) | Entraînement en 2 étapes: Stage 1.0: Entraînement de l'adaptateur d'image (données de légendes d'images à l'échelle Web, japonais:anglais = 75:25), Stage 1.5: Instruction Tuning et adaptation visuelle au japonais via LoRA (VQA, Visual Grounding, détection d'objets, détection d'anomalies, compréhension du travail en usine) | Preferred Networks | PLaMo community license |
 
 ##### Spécifique à un domaine


### PR DESCRIPTION
## Summary
- Jagle-VL 2.2B (LLM-jp 開発の VLM、Qwen3-1.7B + siglip2-so400m-patch16-512 + 2層MLP、InternVL3.0 を参考) を「視覚言語モデル / 画像+テキストからのテキスト生成 / スクラッチ学習モデル / 汎用」テーブルに追加。
- 3 バリアント (`-Jagle` / `-FineVision` / `-Jagle-FineVision`) は学習データのみ異なる同サイズ (2.2B) モデルのため 1 行に集約。学習データ列で各サフィックスの対応を散文で説明。
- ja/en/fr 3 言語すべて同時に更新。配置は Sarashina2.2-Vision-3B (3.8B) と PLaMo 2.1 2B VL (2B) の間 (パラメータサイズ降順)。

## あわせて反映した内容
- 「スクラッチ学習モデル」節に分類基準の注釈を追加 (ベースの LLM は国内モデル/海外モデルを問わない旨)。`Jagle-VL` のベース LLM が海外モデル (Qwen3-1.7B) のため、既存読者の混乱を防ぐ目的。
- `.claude/rules/vlm-addition.md`: スクラッチ判定基準を「LLM + 視覚エンコーダによる新規構築」と明確化し、スクラッチ vs 海外追加学習の判別例 (NABLA-VL, Jagle-VL, LLM-jp-4-VL vs KARAKURI VL 2, Stockmark-DocReasoner) を追記。
- `.claude/rules/table-formatting.md`: テーブルセル内で行頭ハイフン箇条書きを使わない旨と推奨パターンを追記。

## 情報源
- 論文: https://arxiv.org/abs/2604.02048
- HF Collection: https://huggingface.co/collections/llm-jp/jagle
- 解説ブログ: https://speed1313.github.io/posts/Jagle/

## Test plan
- [x] ja/en/fr 3 言語版の表で Jagle-VL 2.2B 行が同位置 (Sarashina2.2-Vision-3B と PLaMo 2.1 2B VL の間) に挿入されていること
- [x] 各バリアントの HuggingFace リンクが正しいこと (`-Jagle`, `-FineVision`, `-Jagle-FineVision`)
- [x] 3 言語版とも「スクラッチ学習モデル」見出し直下に分類注釈が表示されること
- [x] VitePress (`yarn docs:dev`) でレイアウト崩れがないこと

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)