### PR TITLE
LayoutLMv2 / LayoutLMv3 論文の追加と追加ルールの整備

### DIFF
--- a/.claude/rules/model-addition.md
+++ b/.claude/rules/model-addition.md
@@ -31,6 +31,14 @@ Encoder / embedding models (BERT, RoBERTa, DeBERTa, ELECTRA, LUKE, BigBird, Mode
 - The table columns differ from the generative tables: `モデル | アーキテクチャ | 最大トークン長 | 学習テキスト | 開発元 | ライセンス | 公開`.
 - **最大トークン長 gotcha**: RoBERTa-based models report `max_position_embeddings` with a +2 offset (e.g., `514` → effective **512**). Write the effective length, matching sibling rows.
 
+## Architecture Reference Paper — add alongside the model (easy to forget)
+
+Adding a model and adding its **base architecture's foundational paper** are **one task, not two**. Whenever you add a model, check whether its architecture already has a row in `parts/references_model.md`; if the paper is missing, **add it in the same change** without waiting to be asked.
+
+- Example: adding `layoutlmv3-japanese-preview` requires a **LayoutLMv3** row in `references_model.md`. If absent, add the paper too — do not stop at the model row.
+- Only the **architecture / method paper** belongs there (e.g., LayoutLMv3, Qwen3, ModernBERT), NOT every individual Japanese model. A new model whose architecture is already listed needs no reference addition.
+- For the references row format/ordering, see `references-addition.md`.
+
 ## Training Data Column
 
 | Situation | What to write |

--- a/.claude/rules/model-addition.md
+++ b/.claude/rules/model-addition.md
@@ -23,6 +23,14 @@ Models are classified into sections based on training approach. **Evidence is re
 - "Optimized for Japanese" or "Japanese chat model" alone is NOT evidence of continual pre-training
 - Models derived from Japanese continual pre-training models (e.g., Swallow, ELYZA) belong in 継続事前学習 section
 
+## Non-generative (encoder / embedding) models
+
+Encoder / embedding models (BERT, RoBERTa, DeBERTa, ELECTRA, LUKE, BigBird, ModernBERT, **LayoutLM / LayoutLMv2 / LayoutLMv3**, etc.) do **NOT** belong in the generative LLM sections above. They go in the **autoencoding (エンコーダ) section**, which is split into 汎用 and ドメイン特化型.
+
+- Within 汎用, place a new model next to its **architecture family** (e.g., a new LayoutLM variant directly after the existing LayoutLM entry), following the section's existing grouping rather than strict size ordering.
+- The table columns differ from the generative tables: `モデル | アーキテクチャ | 最大トークン長 | 学習テキスト | 開発元 | ライセンス | 公開`.
+- **最大トークン長 gotcha**: RoBERTa-based models report `max_position_embeddings` with a +2 offset (e.g., `514` → effective **512**). Write the effective length, matching sibling rows.
+
 ## Training Data Column
 
 | Situation | What to write |

--- a/.claude/rules/model-addition.md
+++ b/.claude/rules/model-addition.md
@@ -56,11 +56,7 @@ Write the official license name (e.g., "Apache 2.0", "Llama 3 Community License"
 **How to check:**
 - Before adding, scan the model card for sections titled Limitations, Disclaimers, Use Restrictions, 利用上の注意, 制限事項, ご利用にあたって, etc.
 - Look for phrases like "研究開発目的のみ", "research and development purposes only", "not for commercial use", "実臨床での利用は推奨しない", "商用利用には連絡が必要"
-
-**Existing precedents** (consult these for footnote style):
-- `[^13]` — KARAKURI LM: 商用利用には開発元への直接連絡が必要
-- `[^14]` — マージモデル: 研究および教育を目的とした利用を念頭に置く
-- `[^25]` — SIP-med-LLM: 研究開発目的のみでの使用想定、実臨床利用は非推奨
+- For footnote style, mirror an existing `[^n]` footnote in the file.
 
 ## Information Verification Checklist
 
@@ -76,8 +72,4 @@ Write the official license name (e.g., "Apache 2.0", "Llama 3 Community License"
 
 **Press release scope check**: Press releases often describe a model family (e.g., 32B + 8B). Training details quoted from a press release may apply only to the flagship variant. Match each claim to the specific size/variant being added.
 
-**WebFetch summary caveats**: WebFetch returns AI-summarized content that can:
-- Conflate future plans ("will utilize X") with applied techniques ("used X")
-- Flatten "based on (acknowledgment)" into "merged from / fine-tuned from"
-- Drop tense and conditional markers
-When a WebFetch summary mentions "merged", "based on multiple", or any training method, re-fetch with a quote-only prompt or read the page directly to verify.
+**WebFetch summary caveats**: WebFetch returns AI-summarized text that may flatten "based on (acknowledgment)" into "merged/fine-tuned from", conflate future plans with applied techniques, or drop tense. When a summary mentions "merged", "based on multiple", or any training method, re-fetch with a quote-only prompt or read the page directly.

--- a/.claude/rules/references-addition.md
+++ b/.claude/rules/references-addition.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "parts/references_model.md"
+  - "parts/references_training.md"
+---
+
+# Reference (Paper) Addition Guidelines
+
+These files are chronological tables of foundational papers/methods. Columns:
+`モデル・手法名 | 日付 | 会議 | 論文リンク`.
+
+## Ordering (Most Important)
+
+- Rows are sorted in **ascending chronological order by the 日付 column**. Insert a new row at the position matching its date — do NOT append to the end.
+- The 日付 is the **arXiv v1 submission date**, formatted `YYYY.MM.DD`. It is NOT the publication/conference date. Check the arXiv abstract page's `[v1]` timestamp (e.g., "Tue, 29 Dec 2020" → `2020.12.29`).
+- For papers without arXiv (e.g., OpenAI tech reports), use the public release date of the document.
+
+## 会議 (Venue) column
+
+- Write the **publication venue**, not arXiv. Use the conference abbreviation + year:
+  - Examples: `ACL 2021`, `EMNLP 2020`, `NAACL 2022`, `NeurIPS 2022`, `ICLR 2023`, `ICML 2023`, `ICCV 2023`, `CVPR 2024`, `ACM MM 2022` (= ACM Multimedia), `KDD 2020`.
+  - Findings tracks: `EMNLP 2023 (Findings)`. Workshops: `<Workshop> at <Conf> YYYY`.
+- If the paper is a preprint only (no venue), use `-`.
+
+## 論文 (Paper) link
+
+- Prefer the **ACL Anthology** URL when the paper is in it; otherwise use the **arXiv abstract** URL (`https://arxiv.org/abs/XXXX.XXXXX`).
+- Link the paper's full title as the anchor text.
+
+## Verification
+
+- Confirm both the v1 date and the venue from the arXiv abstract page (the "Comments" / "Journal reference" field often names the venue). Do not infer the venue from memory.

--- a/.claude/rules/references-addition.md
+++ b/.claude/rules/references-addition.md
@@ -6,29 +6,11 @@ paths:
 
 # Reference (Paper) Addition Guidelines
 
-These files are chronological tables of foundational papers/methods. Columns:
-`モデル・手法名 | 日付 | 会議 | 論文リンク`.
+Chronological tables of foundational papers/methods. Columns: `モデル・手法名 | 日付 | 会議 | 論文リンク`.
 
-> Note: the main trigger for editing this file is a **model addition** — when you add a model whose base architecture is not yet listed here, add the architecture paper as part of that same change. See `model-addition.md` ("Architecture Reference Paper"). This file only covers *how* to format the row.
+> Trigger: this is usually edited as part of a **model addition** — when a model's base architecture is not yet listed, add the architecture paper in the same change. See `model-addition.md` ("Architecture Reference Paper").
 
-## Ordering (Most Important)
-
-- Rows are sorted in **ascending chronological order by the 日付 column**. Insert a new row at the position matching its date — do NOT append to the end.
-- The 日付 is the **arXiv v1 submission date**, formatted `YYYY.MM.DD`. It is NOT the publication/conference date. Check the arXiv abstract page's `[v1]` timestamp (e.g., "Tue, 29 Dec 2020" → `2020.12.29`).
-- For papers without arXiv (e.g., OpenAI tech reports), use the public release date of the document.
-
-## 会議 (Venue) column
-
-- Write the **publication venue**, not arXiv. Use the conference abbreviation + year:
-  - Examples: `ACL 2021`, `EMNLP 2020`, `NAACL 2022`, `NeurIPS 2022`, `ICLR 2023`, `ICML 2023`, `ICCV 2023`, `CVPR 2024`, `ACM MM 2022` (= ACM Multimedia), `KDD 2020`.
-  - Findings tracks: `EMNLP 2023 (Findings)`. Workshops: `<Workshop> at <Conf> YYYY`.
-- If the paper is a preprint only (no venue), use `-`.
-
-## 論文 (Paper) link
-
-- Prefer the **ACL Anthology** URL when the paper is in it; otherwise use the **arXiv abstract** URL (`https://arxiv.org/abs/XXXX.XXXXX`).
-- Link the paper's full title as the anchor text.
-
-## Verification
-
-- Confirm both the v1 date and the venue from the arXiv abstract page (the "Comments" / "Journal reference" field often names the venue). Do not infer the venue from memory.
+- **Order**: ascending by 日付; insert at the matching position, don't append.
+- **日付**: arXiv v1 submission date as `YYYY.MM.DD` (the `[v1]` timestamp, NOT the publication date). For papers without arXiv, use the document's release date.
+- **会議**: publication venue as abbreviation + year (`ACL 2021`, `NeurIPS 2022`, `ACM MM 2022` = ACM Multimedia, `EMNLP 2023 (Findings)`); preprint-only → `-`. Confirm from the arXiv "Comments" / "Journal reference" field, not from memory.
+- **論文 link**: ACL Anthology URL if available, else arXiv abstract URL; anchor on the paper's full title.

--- a/.claude/rules/references-addition.md
+++ b/.claude/rules/references-addition.md
@@ -9,6 +9,8 @@ paths:
 These files are chronological tables of foundational papers/methods. Columns:
 `モデル・手法名 | 日付 | 会議 | 論文リンク`.
 
+> Note: the main trigger for editing this file is a **model addition** — when you add a model whose base architecture is not yet listed here, add the architecture paper as part of that same change. See `model-addition.md` ("Architecture Reference Paper"). This file only covers *how* to format the row.
+
 ## Ordering (Most Important)
 
 - Rows are sorted in **ascending chronological order by the 日付 column**. Insert a new row at the position matching its date — do NOT append to the end.

--- a/.claude/rules/table-formatting.md
+++ b/.claude/rules/table-formatting.md
@@ -13,6 +13,7 @@ paths:
 - **License format**: Use official names with consistent capitalization
 - **Release year bolding**: The latest/newest release year (e.g., the current year) should be **bolded** in the table. When the year is no longer the newest, the bold is removed (see commit history for precedent).
 - **Developer column for individuals**: When the developer is an individual (not a company/university/research lab), use the format `個人 (name)` (JA) / `Individual (name)` (EN) / `Individuel (name)` (FR). Do NOT write the HuggingFace username alone.
+- **Developer column — canonical organization names**: Use the project's established label for an organization, consistent across all three language files. When unsure, **grep an existing row for the same developer** rather than inventing a label from the HuggingFace org name. Notable case: LLM-jp models use 「大規模言語モデル研究開発センター」(JA) / "Research and Development Center for Large Language Models" (EN) / "Centre de recherche et développement pour les grands modèles de langage" (FR) — NOT "LLM-jp".
 
 # Cell Content Formatting
 

--- a/parts/references_model.md
+++ b/parts/references_model.md
@@ -20,6 +20,7 @@
 | wav2vec 2.0 | 2020.06.20 | NeurIPS 2020 | [wav2vec 2.0: A Framework for Self-Supervised Learning of Speech Representations](https://arxiv.org/abs/2006.11477) |
 | BigBird | 2020.07.28 | NeurIPS 2020 | [Big Bird: Transformers for Longer Sequences](https://arxiv.org/abs/2007.14062) |
 | LUKE | 2020.10.02 | EMNLP 2020 | [LUKE: Deep Contextualized Entity Representations with Entity-aware Self-attention](https://aclanthology.org/2020.emnlp-main.523/) |
+| LayoutLMv2 | 2020.12.29 | ACL 2021 | [LayoutLMv2: Multi-modal Pre-training for Visually-Rich Document Understanding](https://arxiv.org/abs/2012.14740) |
 | CLIP | 2021.02.26 | ICML 2021 | [Learning Transferable Visual Models From Natural Language Supervision](https://arxiv.org/abs/2103.00020) |
 | SimCSE | 2021.04.18 | EMNLP 2021 | [SimCSE: Simple Contrastive Learning of Sentence Embeddings](https://aclanthology.org/2021.emnlp-main.552/) |
 | RoFormer | 2021.04.20 | - | [RoFormer: Enhanced Transformer with Rotary Position Embedding](https://arxiv.org/abs/2104.09864) |
@@ -33,6 +34,7 @@
 | MixCSE | 2022.02.22 | AAAI 2022 | [Unsupervised Sentence Representation via Contrastive Learning with Mixing Negatives](https://ojs.aaai.org/index.php/AAAI/article/view/21428) |
 | InstructGPT | 2022.03.04 | NeurIPS 2022 | [Training language models to follow instructions with human feedback](https://arxiv.org/abs/2203.02155) |
 | GPT-NeoX | 2022.04.14 | BigScience Research Workshop at ACL 2022 | [GPT-NeoX-20B: An Open-Source Autoregressive Language Model](https://aclanthology.org/2022.bigscience-1.9/) |
+| LayoutLMv3 | 2022.04.18 | ACM MM 2022 | [LayoutLMv3: Pre-training for Document AI with Unified Text and Image Masking](https://arxiv.org/abs/2204.08387) |
 | DiffCSE | 2022.04.21 | NAACL 2022 | [DiffCSE: Difference-based Contrastive Learning for Sentence Embeddings](https://aclanthology.org/2022.naacl-main.311/) |
 | GIT | 2022.05.27 | TMLR 2022 | [GIT: A Generative Image-to-text Transformer for Vision and Language](https://arxiv.org/abs/2205.14100) |
 | CogVideo | 2022.05.29 | ICLR 2023 | [CogVideo: Large-scale Pretraining for Text-to-Video Generation via Transformers](https://arxiv.org/abs/2205.15868) |


### PR DESCRIPTION
## 概要

LayoutLMv2 / LayoutLMv3 論文の追加と、その過程で判明した**ルールの空白**の整備を行いました。

### 1. 参照論文の追加

| モデル | 日付 | 会議 | 論文 |
|---|---|---|---|
| LayoutLMv2 | 2020.12.29 | ACL 2021 | [LayoutLMv2: Multi-modal Pre-training for Visually-Rich Document Understanding](https://arxiv.org/abs/2012.14740) |
| LayoutLMv3 | 2022.04.18 | ACM MM 2022 | [LayoutLMv3: Pre-training for Document AI with Unified Text and Image Masking](https://arxiv.org/abs/2204.08387) |

- 日付は各 arXiv の v1 投稿日、会議は出版先。年表の時系列順に挿入。

### 2. ルールの整備（本質的な課題への対応）

今回の課題は論文追加の**フォーマット**ではなく、「**モデルを追加したら、そのアーキテクチャの大元の論文も同時に references に追加されるべき**なのに、それが連動チェックとして促されないこと」でした。layoutlmv3-japanese-preview を追加した時点で LayoutLMv3 論文も入れるべきだったのに、後から別タスクになってしまったのが典型例です。

- **`model-addition.md`**: 「Architecture Reference Paper」セクションを追加。**モデル追加とアーキテクチャ論文追加は1タスク**であり、`references_model.md` に大元の論文が無ければ同じ変更で追加する、と明文化（対象はアーキテクチャ/手法の論文のみ。個々の日本語モデルは対象外）。あわせてエンコーダ系モデルの配置ルールと `max_position_embeddings` の +2 オフセット（514→実効512）も追記。
- **`references-addition.md`（新規）**: 上記ステップを支える**書式リファレンス**（時系列・arXiv v1 日付・会議の略記・リンク方針）。トリガーは model-addition 側にある旨を明記。
- **`table-formatting.md`**: 開発元の正式表記ルール（迷ったら既存行を grep、LLM-jp の3言語正式名称）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)