### PR TITLE
モデルのサイズ別行分割ルールの修正と CLAUDE.md の整理

### DIFF
--- a/.claude/rules/table-formatting.md
+++ b/.claude/rules/table-formatting.md
@@ -9,7 +9,7 @@ paths:
 
 - **Parameter size ordering**: Descending order within each section (largest first)
 - **Architecture column**: Base architecture name (e.g., "Llama 3.1", "Qwen2.5"), NOT attention mechanisms
-- **Multiple sizes**: Combine into single row: `([**7b**](url1), [**13b**](url2))`
+- **Multiple sizes**: Use a **separate row per size**, in descending parameter-size order. Do NOT combine multiple sizes into a single row.
 - **License format**: Use official names with consistent capitalization
 - **Release year bolding**: The latest/newest release year (e.g., the current year) should be **bolded** in the table. When the year is no longer the newest, the bold is removed (see commit history for precedent).
 - **Developer column for individuals**: When the developer is an individual (not a company/university/research lab), use the format `個人 (name)` (JA) / `Individual (name)` (EN) / `Individuel (name)` (FR). Do NOT write the HuggingFace username alone.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,27 +1,5 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Project Overview
-
-This is a documentation project that maintains a comprehensive list of Japanese Large Language Models (LLMs) and their evaluation benchmarks. The project uses VitePress for documentation site generation.
-
-## Common Commands
-
-```bash
-yarn docs:dev      # Start development server
-yarn docs:build    # Build documentation site
-yarn docs:preview  # Preview built documentation
-```
-
-## Project Structure
-
-- **README.md** - Main Japanese documentation (primary content)
-- **en/README.md** - English translation
-- **fr/README.md** - French translation
-- **parts/references_model.md** - Model reference chronology
-- **parts/references_training.md** - Training method references
-
 ## Editing Rules
 
 Editing rules for README files are defined in `.claude/rules/` as conditional rules that activate when working with the relevant files.


### PR DESCRIPTION
## 概要

Claude Code 向けの設定ファイル 2 件を整理します。README 本体の内容は変更しません。

## 変更内容

### 1. `.claude/rules/table-formatting.md` — サイズ別行分割ルールの修正

複数サイズを持つモデルについて、これまでルールは「1 行にまとめる」と指示していましたが、実際の運用（既存の Qwen 系モデル等）ではサイズごとに行を分けており、ルールと実態が食い違っていました。実態に合わせて修正します。

```diff
- - **Multiple sizes**: Combine into single row: `([**7b**](url1), [**13b**](url2))`
+ - **Multiple sizes**: Use a **separate row per size**, in descending parameter-size order. Do NOT combine multiple sizes into a single row.
```

### 2. `CLAUDE.md` — リポジトリから復元できる記述の削除

以下はセッション開始時に毎回読み込まれますが、いずれもコード側から辿れる情報のため削除しました。

- **Project Overview** — `README.md` と `package.json` の `vitepress` 依存から判明
- **Common Commands** — `package.json` の `scripts` と同一内容
- **Project Structure** — `ls` で分かるファイル構成

`.claude/rules/` への参照は、他所にある文脈への案内であり復元できないため残しています。

## 補足

1 点目はルールの向きを逆にする変更です。既存の README に複数サイズを 1 行にまとめた記載が残っている場合、今後の追加分と表記が混在する可能性があります（本 PR では README には手を入れていません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)