### PR TITLE
Sakana Namazu を追加

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -27,3 +27,6 @@ https?://www\.lightblue-tech\.com/.*
 
 # Informatix (rejects bot Accept header with 415)
 https?://www\.informatix\.co\.jp/.*
+
+# Google Developers Blog (rate limits bot access with 429)
+https?://developers-jp\.googleblog\.com/.*

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@
 | [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | オルツ | AWS Marketplace (SageMaker) |
 | [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | カラクリ, Upstage | AWS Marketplace (SageMaker) |
 | [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | 2024 | | NTT | Microsoft Foundry |
+| [Sakana Namazu](https://sakana.ai/namazu/)<br>([sakana-namazu](https://console.sakana.ai/models?model=sakana-namazu)) | **2026** | 262,144 | Sakana AI | 独自 |
 
 <a id="autoencoding"></a>
 ## 入力テキストの処理に主に使うモデル

--- a/en/README.md
+++ b/en/README.md
@@ -312,6 +312,7 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 | [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | alt Inc. | AWS Marketplace (SageMaker) |
 | [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | KARAKURI, Upstage | AWS Marketplace (SageMaker) |
 | [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | 2024 | | NTT | Microsoft Foundry |
+| [Sakana Namazu](https://sakana.ai/namazu/)<br>([sakana-namazu](https://console.sakana.ai/models?model=sakana-namazu)) | **2026** | 262,144 | Sakana AI | self-owned |
 
 <a id="autoencoding"></a>
 ## Encoder models

--- a/fr/README.md
+++ b/fr/README.md
@@ -312,6 +312,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 | [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | alt Inc. | AWS Marketplace (SageMaker) |
 | [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | KARAKURI, Upstage | AWS Marketplace (SageMaker) |
 | [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | 2024 | | NTT | Microsoft Foundry |
+| [Sakana Namazu](https://sakana.ai/namazu/)<br>([sakana-namazu](https://console.sakana.ai/models?model=sakana-namazu)) | **2026** | 262,144 | Sakana AI | self-owned |
 
 <a id="autoencoding"></a>
 ## Modèles encodeur

--- a/parts/references_model.md
+++ b/parts/references_model.md
@@ -95,6 +95,7 @@
 | Nemotron-Nano | 2025.08.20 | - | [NVIDIA Nemotron Nano 2: An Accurate and Efficient Hybrid Mamba-Transformer Reasoning Model](https://arxiv.org/abs/2508.14444) |
 | Dream | 2025.08.21 | - | [Dream 7B: Diffusion Large Language Models](https://arxiv.org/abs/2508.15487) |
 | Qwen3 | 2025.05.14 | - | [Qwen3 Technical Report](https://arxiv.org/abs/2505.09388) |
+| Kimi K2 | 2025.07.28 | - | [Kimi K2: Open Agentic Intelligence](https://arxiv.org/abs/2507.20534) |
 | GPT-OSS | 2025.08.08 | - | [gpt-oss-120b & gpt-oss-20b Model Card](https://arxiv.org/abs/2508.10925) |
 | GLM-4.5 | 2025.08.08 | - | [GLM-4.5: Agentic, Reasoning, and Coding (ARC) Foundation Models](https://arxiv.org/abs/2508.06471) |
 | PLaMo 2 | 2025.09.05 | - | [PLaMo 2 Technical Report](https://arxiv.org/abs/2509.04897) |


### PR DESCRIPTION
Closes #697

## 追加内容

### Sakana Namazu（APIとして提供されているモデル）

| 項目 | 内容 |
|---|---|
| 公開 | 2026年8月3日 |
| 開発元 | Sakana AI |
| ベースモデル | Kimi K2.6（Moonshot AI）に独自データで事後学習 |
| コンテキスト長 | 262,144 |
| プラットフォーム | 独自（console.sakana.ai） |

- 重みは公開されておらず API 提供のみのため、「APIとして提供されているモデル」に配置した。
- コンテキスト長は[コンソールのモデルページ](https://console.sakana.ai/models?model=sakana-namazu)の記載が「256K tokens」で正確な整数値の明示がないため、ベースモデル Kimi K2.6 の `config.json` の `max_position_embeddings`（262,144）に合わせ、表内の他行と同じ整数表記とした。

### Kimi K2 の原論文

ベースアーキテクチャの論文として [Kimi K2: Open Agentic Intelligence](https://arxiv.org/abs/2507.20534)（2025.07.28）を `parts/references_model.md` に追加した。K2.6 自体の論文は確認できなかったため、シリーズのテクニカルレポートを掲載している。

## 出典

- https://sakana.ai/namazu/
- https://sakana.ai/namazu-api/
- https://console.sakana.ai/models?model=sakana-namazu

🤖 Generated with [Claude Code](https://claude.com/claude-code)