### PR TITLE
公開年による絞り込みUIを追加 (#633)

### DIFF
--- a/.vitepress/theme/YearFilter.ts
+++ b/.vitepress/theme/YearFilter.ts
@@ -1,0 +1,158 @@
+import { defineComponent, h, ref, onMounted, watch, nextTick } from 'vue'
+import { useData, useRoute } from 'vitepress'
+
+const STORAGE_KEY = 'ajl-year-filter'
+
+/** 「公開年」列を見分けるためのヘッダラベル (JA / EN / FR) */
+const YEAR_HEADERS = new Set(['公開年', 'release year', 'année de sortie'])
+
+/** 「すべて表示」を表す閾値 */
+const ALL = 0
+
+interface Labels {
+  legend: string
+  all: string
+  since: (year: number) => string
+  empty: string
+}
+
+const LABELS: Record<string, Labels> = {
+  'en-US': {
+    legend: 'Release year',
+    all: 'All',
+    since: (year) => `${year} and later`,
+    empty: 'No models match this filter.',
+  },
+  'fr-FR': {
+    legend: 'Année de sortie',
+    all: 'Toutes',
+    since: (year) => `${year} et après`,
+    empty: 'Aucun modèle ne correspond à ce filtre.',
+  },
+  'ja-JP': {
+    legend: '公開年',
+    all: 'すべて',
+    since: (year) => `${year}年以降`,
+    empty: '該当するモデルはありません。',
+  },
+}
+
+interface YearTable {
+  el: HTMLTableElement
+  rows: { el: HTMLTableRowElement; year: number }[]
+  /** 全行が隠れたときにテーブルの代わりに表示する要素 */
+  placeholder: HTMLParagraphElement
+}
+
+/** 公開年列を持つテーブルを、各行の公開年つきで集める */
+function collectTables(emptyMessage: string): YearTable[] {
+  const tables: YearTable[] = []
+
+  document.querySelectorAll<HTMLTableElement>('.vp-doc table').forEach((el) => {
+    const headers = Array.from(el.querySelectorAll<HTMLTableCellElement>('thead th'))
+    const index = headers.findIndex((th) =>
+      YEAR_HEADERS.has((th.textContent ?? '').trim().toLowerCase())
+    )
+    if (index < 0) return
+
+    const rows: YearTable['rows'] = []
+    el.querySelectorAll<HTMLTableRowElement>('tbody tr').forEach((tr) => {
+      const matched = (tr.cells[index]?.textContent ?? '').match(/\d{4}/)
+      if (matched) rows.push({ el: tr, year: Number(matched[0]) })
+    })
+    if (rows.length === 0) return
+
+    const placeholder = document.createElement('p')
+    placeholder.className = 'year-filter-empty'
+    placeholder.textContent = emptyMessage
+    placeholder.style.display = 'none'
+    el.insertAdjacentElement('afterend', placeholder)
+
+    tables.push({ el, rows, placeholder })
+  })
+
+  return tables
+}
+
+function loadThreshold(): number {
+  const stored = Number(localStorage.getItem(STORAGE_KEY))
+  return Number.isFinite(stored) && stored > 0 ? stored : ALL
+}
+
+export default defineComponent({
+  name: 'YearFilter',
+  setup() {
+    const { lang } = useData()
+    const route = useRoute()
+    const tables = ref<YearTable[]>([])
+    const years = ref<number[]>([])
+    const threshold = ref(ALL)
+
+    function labels(): Labels {
+      return LABELS[lang.value] ?? LABELS['ja-JP']
+    }
+
+    function apply(): void {
+      tables.value.forEach(({ el, rows, placeholder }) => {
+        let visible = 0
+        rows.forEach((row) => {
+          const shown = threshold.value === ALL || row.year >= threshold.value
+          row.el.style.display = shown ? '' : 'none'
+          if (shown) visible += 1
+        })
+        // 全行が消えるとヘッダだけのテーブルが残るため、代わりに文言を出す
+        el.style.display = visible === 0 ? 'none' : ''
+        placeholder.style.display = visible === 0 ? '' : 'none'
+      })
+    }
+
+    function scan(): void {
+      tables.value = collectTables(labels().empty)
+      years.value = [
+        ...new Set(tables.value.flatMap(({ rows }) => rows.map((row) => row.year))),
+      ].sort((a, b) => b - a)
+      apply()
+    }
+
+    function onChange(event: Event): void {
+      threshold.value = Number((event.target as HTMLSelectElement).value)
+      localStorage.setItem(STORAGE_KEY, String(threshold.value))
+      apply()
+    }
+
+    onMounted(() => {
+      threshold.value = loadThreshold()
+      scan()
+    })
+
+    // VitePress は SPA 遷移で本文 DOM を差し替えるため、ページごとに集め直す
+    watch(
+      () => route.path,
+      () => nextTick(scan)
+    )
+
+    return () => {
+      if (years.value.length === 0) return null
+
+      const { legend, all, since } = labels()
+
+      return h('div', { class: 'year-filter' }, [
+        h('label', { class: 'year-filter-legend', for: 'year-filter-select' }, legend),
+        h(
+          'select',
+          {
+            id: 'year-filter-select',
+            class: 'year-filter-select',
+            onChange,
+          },
+          [
+            h('option', { value: String(ALL), selected: threshold.value === ALL }, all),
+            ...years.value.map((year) =>
+              h('option', { value: String(year), selected: threshold.value === year }, since(year))
+            ),
+          ]
+        ),
+      ])
+    }
+  },
+})

--- a/.vitepress/theme/index.mts
+++ b/.vitepress/theme/index.mts
@@ -1,14 +1,16 @@
 import DefaultTheme from 'vitepress/theme'
 import BackToTop from './BackToTop'
+import YearFilter from './YearFilter'
 import { h } from 'vue'
 import './custom.css'
 import './back-to-top.css'
+import './year-filter.css'
 
 export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
-      'layout-bottom': () => h(BackToTop),
+      'layout-bottom': () => [h(YearFilter), h(BackToTop)],
     })
   },
 }

--- a/.vitepress/theme/year-filter.css
+++ b/.vitepress/theme/year-filter.css
@@ -1,0 +1,46 @@
+.year-filter {
+  position: fixed;
+  bottom: 2rem;
+  right: 5.5rem;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 3rem;
+  padding: 0 0.875rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transition: border-color 0.25s;
+}
+
+.year-filter:focus-within {
+  border-color: var(--vp-c-brand-1);
+}
+
+.year-filter-legend {
+  color: var(--vp-c-text-2);
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+
+.year-filter-select {
+  border: none;
+  background: transparent;
+  color: var(--vp-c-text-1);
+  font-size: 0.875rem;
+  cursor: pointer;
+  outline: none;
+}
+
+.year-filter-empty {
+  color: var(--vp-c-text-3);
+  font-size: 0.875rem;
+}
+
+@media (max-width: 640px) {
+  .year-filter-legend {
+    display: none;
+  }
+}

--- a/fr/README.md
+++ b/fr/README.md
@@ -119,7 +119,7 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 <a id="generative-continual-general"></a>
 #### D'usage général
 
-|    | Année de publication | Base du Model  |  Données d'entraînement  |  Développeur  |  Licence / Conditions d'utilisation  |
+|    | Année de sortie | Base du Model  |  Données d'entraînement  |  Développeur  |  Licence / Conditions d'utilisation  |
 |:---|:---:|:---:|:---:|:---:|:---:|
 | [GPT-OSS Swallow 120B](https://swallow-llm.github.io/gptoss-swallow.ja.html)<br>([120B-SFT-v0.1](https://huggingface.co/tokyotech-llm/GPT-OSS-Swallow-120B-SFT-v0.1), [120B-RL-v0.1](https://huggingface.co/tokyotech-llm/GPT-OSS-Swallow-120B-RL-v0.1), [120B-RL-v0.1-MXFP4](https://huggingface.co/tokyotech-llm/GPT-OSS-Swallow-120B-RL-v0.1-MXFP4)) | **2026** | GPT-OSS (**120b**) | Pré-entraînement : Wikipedia, Swallow Corpus v3.2, Nemotron-CC, Cosmopedia, Laboro ParaCorpus, Swallow Math v2, Swallow Code v2<br>(**419.4B** tokens)<br>SFT : GPT-OSS-LMSYS-Chat-1M-Synth, Swallow-Nemotron-Post-Training-Dataset-v1<br>RL : allenai/Dolci-Think-RL-7B (Math subset) | Swallow Project | Apache 2.0 |
 | [Llama 3.3 Swallow 70B](https://swallow-llm.github.io/llama3.3-swallow.en.html)<br>([70B-v0.4](https://huggingface.co/tokyotech-llm/Llama-3.3-Swallow-70B-v0.4), [70B-Instruct-v0.4](https://huggingface.co/tokyotech-llm/Llama-3.3-Swallow-70B-Instruct-v0.4)) | 2025 | Llama 3.3 (**70b**) | Pre-training: Wikipedia, DCLM-baseline-1.0, Swallow Corpus Version 2, Cosmopedia, Laboro ParaCorpus, FineMath-4+, Swallow Code Version 0.3<br>Instruction Tuning: Gemma-2-LMSYS-Chat-1M-Synth, Swallow-Magpie-Ultra-v0.1, Swallow-Gemma-Magpie-v0.1, Swallow-Code-v0.3-Instruct-style | Swallow Project | Llama 3.3 Community License & Gemma Terms of Use |


### PR DESCRIPTION
## 概要

[#633](https://github.com/llm-jp/awesome-japanese-llm/issues/633)「〜〜年以降のモデルのみ表示」の絞り込みUIを実装します。下準備（全モデルテーブルへの公開年列追加、#662 / #663 / #664 / #681 / #699）が完了したので、本題の UI です。

公開年列を持つテーブルを DOM から検出し、選択した年より前のモデルの行を隠します。

## 設計

**一括適用 + フローティング配置**

- 公開年列を持つテーブルは26個あるため、テーブルごとにコントロールを置くとページのノイズになります。ページ全体に一括で効く形にしました
- ただしページ上部固定だと下までスクロールしたときに操作できないため、既存の BackToTop と同じくフローティング（右下）にしています

**言語対応**

- 「公開年 / Release Year / Année de sortie」のいずれかをヘッダに持つ列を探すので、3言語すべてで同じコードが動きます
- UI のラベルは `useData().lang` で切り替え（`公開年` / `Release year` / `Année de sortie`）

**状態**

- 年の選択肢はページ上の公開年から自動生成するため、今後モデルが増えてもコード変更は不要です（現状 2026〜2019）
- 選択は localStorage に保存し、リロード・言語切り替え後も復元されます
- デフォルトは「すべて」。初回訪問時と静的 HTML は全件表示のままなので、検索エンジンや JS 無効環境でも情報が欠けません

**空になったテーブルの扱い**

全行が隠れるとヘッダだけのテーブルが残るため、テーブルを隠して「該当するモデルはありません。」に差し替えます。見出しは残しています（目次サイドバーは見出しベースなので、見出しごと消すと実体のない項目がサイドバーに残るため）。

## あわせて修正

`fr/README.md` の「海外モデルに日本語で継続事前学習を行ったモデル / 汎用」テーブルのヘッダだけ `Année de publication` になっており、FR ではこの表（73行）がフィルタ対象から漏れていました。他テーブルと同じ `Année de sortie` に統一しています。

## 動作確認

`yarn docs:build` が通ることに加えて、headless Chrome で JS 実行後の DOM を取得して挙動を確認しました。

| 選択 | 非表示になった行 | 空になったテーブル |
|:---|---:|---:|
| すべて | 0 / 365 | 0 / 26 |
| 2024年以降 | 117 | 0 |
| 2026年以降 | 322 | 12 |

- JA / EN / FR の3ページとも26テーブル365行を検出（FR のヘッダ修正後）
- localStorage による選択の復元、locale ごとのラベル切り替えも確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
