### PR TITLE
tsuzumi 2 を追加、API テーブルを公開年の降順に整理

### DIFF
--- a/.claude/rules/table-formatting.md
+++ b/.claude/rules/table-formatting.md
@@ -9,11 +9,21 @@ paths:
 
 - **Parameter size ordering**: Descending order within each section (largest first)
 - **Architecture column**: Base architecture name (e.g., "Llama 3.1", "Qwen2.5"), NOT attention mechanisms
-- **Multiple sizes**: Use a **separate row per size**, in descending parameter-size order. Do NOT combine multiple sizes into a single row.
+- **Multiple sizes**: Use a **separate row per size**, in descending parameter-size order. Do NOT combine multiple sizes into a single row. This rule is about **sizes of one release**; successive versions of the same series are a different case — see the API table section below and check how the existing row for that series is written before splitting it.
 - **License format**: Use official names with consistent capitalization
 - **Release year bolding**: The latest/newest release year (e.g., the current year) should be **bolded** in the table. When the year is no longer the newest, the bold is removed (see commit history for precedent).
 - **Developer column for individuals**: When the developer is an individual (not a company/university/research lab), use the format `個人 (name)` (JA) / `Individual (name)` (EN) / `Individuel (name)` (FR). Do NOT write the HuggingFace username alone.
 - **Developer column — canonical organization names**: Use the project's established label for an organization, consistent across all three language files. When unsure, **grep an existing row for the same developer** rather than inventing a label from the HuggingFace org name. Notable case: LLM-jp models use 「大規模言語モデル研究開発センター」(JA) / "Research and Development Center for Large Language Models" (EN) / "Centre de recherche et développement pour les grands modèles de langage" (FR) — NOT "LLM-jp".
+
+# 「APIとして提供されているモデル」 Table
+
+Columns: `モデル | 公開年 | 入出力で扱えるトークン数 | 開発元 | プラットフォーム`. This table has no parameter-size column, so the rules above about size ordering do not apply.
+
+- **Ordering**: by 公開年, **descending** (newest first). Within the same year, keep the existing relative order of rows.
+- **One row per model series, not per version.** A new generation of a series already listed (e.g., tsuzumi → tsuzumi 2) goes into the **existing row** as an additional parenthesized link, following the `[series](announcement)<br>([variant](link), [variant](link))` pattern used by Syn / Syn Pro. Do NOT add a second row for it.
+- **公開年 of a multi-version row**: the year of the **newest** version listed. Update the existing value when adding a newer version (and apply the bolding rule above).
+- **公開年 means the year the developer started offering the model**, not the year it appeared on a particular platform. Example: tsuzumi 2 → 2025 (NTT 提供開始 2025-10-20), even though it reached Microsoft Foundry / Azure Marketplace on 2026-05-20.
+- **トークン数**: leave the cell **empty** when the context length is not publicly documented (as with tsuzumi). Do not substitute a figure for a different variant of the same series.
 
 # Cell Content Formatting
 

--- a/.claude/rules/table-formatting.md
+++ b/.claude/rules/table-formatting.md
@@ -33,6 +33,14 @@ Columns: `モデル | 公開年 | 入出力で扱えるトークン数 | 開発�
   - **Prose** — when distinguishing among model variants in the same row (e.g., `-Jagle` / `-FineVision` suffixes), describe the distinction in a single sentence with parenthetical qualifiers, not stacked bullets.
 - `<br>` itself is fine for line breaks; the rule is specifically about avoiding `-` at line starts and avoiding repeated label-style rows that mimic bullet lists for model variants.
 
+# Link Checker (CI)
+
+The `check-links` workflow runs lychee over the three README files with a bot user agent. Some sites answer bots with 403/415/429 or time out even though the URL is fine in a browser — those are listed in `.lycheeignore`.
+
+- After adding a URL from a host not already in `.lycheeignore`, verify it the way CI will:
+  `curl -s -o /dev/null -w "%{http_code}\n" -A "Mozilla/5.0 (compatible; lychee-link-checker)" -L <url>`
+- If it fails only for the bot UA, add a `.lycheeignore` entry **in the same change**, following the existing `# Site (reason)` + regex format. Do not swap in a different URL just to appease the checker.
+
 # Multilingual Consistency
 
 - Update all three files (README.md, en/README.md, fr/README.md) simultaneously

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -30,3 +30,6 @@ https?://www\.informatix\.co\.jp/.*
 
 # Google Developers Blog (rate limits bot access with 429)
 https?://developers-jp\.googleblog\.com/.*
+
+# Microsoft Marketplace (blocks non-browser user agents with 403)
+https?://(azure)?marketplace\.microsoft\.com/.*

--- a/README.md
+++ b/README.md
@@ -307,12 +307,12 @@
 
 |    | 公開年 |  入出力で扱える<br>トークン数 | 開発元  |  プラットフォーム |
 |:---|:---:|:---:|:---:|:---:|
-| [PLaMo API](https://plamo.preferredai.jp/api) | 2024 | 32,768 | Preferred Networks | 独自 |
-| [AIのべりすと](https://ai-novel.com/account_api.php) | 2021 | 2,400 ~ 8,192 | Bit192 | 独自 |
-| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | オルツ | AWS Marketplace (SageMaker) |
-| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | カラクリ, Upstage | AWS Marketplace (SageMaker) |
-| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | 2024 | | NTT | Microsoft Foundry |
 | [Sakana Namazu](https://sakana.ai/namazu/)<br>([sakana-namazu](https://console.sakana.ai/models?model=sakana-namazu)) | **2026** | 262,144 | Sakana AI | 独自 |
+| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | カラクリ, Upstage | AWS Marketplace (SageMaker) |
+| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b), [tsuzumi 2](https://marketplace.microsoft.com/en-us/product/1681106214127.nttdata-tsuzumi-2-instruct-offer)) | 2025 | | NTT | Microsoft Foundry |
+| [PLaMo API](https://plamo.preferredai.jp/api) | 2024 | 32,768 | Preferred Networks | 独自 |
+| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | オルツ | AWS Marketplace (SageMaker) |
+| [AIのべりすと](https://ai-novel.com/account_api.php) | 2021 | 2,400 ~ 8,192 | Bit192 | 独自 |
 
 <a id="autoencoding"></a>
 ## 入力テキストの処理に主に使うモデル

--- a/en/README.md
+++ b/en/README.md
@@ -307,12 +307,12 @@ Please point out any errors on the [issues page](https://github.com/llm-jp/aweso
 
 |    | Release Year |  Max Context Length | Developer  | Platform |
 |:---|:---:|:---:|:---:|:---:|
-| [PLaMo API](https://plamo.preferredai.jp/api) | 2024 | 32,768 | Preferred Networks | self-owned |
-| [AI Novelist](https://ai-novel.com/account_api.php) | 2021 | 2,400 ~ 8,192 | Bit192 | self-owned |
-| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | alt Inc. | AWS Marketplace (SageMaker) |
-| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | KARAKURI, Upstage | AWS Marketplace (SageMaker) |
-| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | 2024 | | NTT | Microsoft Foundry |
 | [Sakana Namazu](https://sakana.ai/namazu/)<br>([sakana-namazu](https://console.sakana.ai/models?model=sakana-namazu)) | **2026** | 262,144 | Sakana AI | self-owned |
+| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | KARAKURI, Upstage | AWS Marketplace (SageMaker) |
+| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b), [tsuzumi 2](https://marketplace.microsoft.com/en-us/product/1681106214127.nttdata-tsuzumi-2-instruct-offer)) | 2025 | | NTT | Microsoft Foundry |
+| [PLaMo API](https://plamo.preferredai.jp/api) | 2024 | 32,768 | Preferred Networks | self-owned |
+| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | alt Inc. | AWS Marketplace (SageMaker) |
+| [AI Novelist](https://ai-novel.com/account_api.php) | 2021 | 2,400 ~ 8,192 | Bit192 | self-owned |
 
 <a id="autoencoding"></a>
 ## Encoder models

--- a/fr/README.md
+++ b/fr/README.md
@@ -307,12 +307,12 @@ N'hésitez pas à signaler les erreurs sur la page [issues](https://github.com/l
 
 |    | Année de sortie |  Longueur Maximale du Contexte | Développeur  | Plateforme |
 |:---|:---:|:---:|:---:|:---:|
-| [PLaMo API](https://plamo.preferredai.jp/api) | 2024 | 32,768 | Preferred Networks | self-owned |
-| [AI Novelist](https://ai-novel.com/account_api.php) | 2021 | 2,400 ~ 8,192 | Bit192 | self-owned |
-| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | alt Inc. | AWS Marketplace (SageMaker) |
-| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | KARAKURI, Upstage | AWS Marketplace (SageMaker) |
-| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b)) | 2024 | | NTT | Microsoft Foundry |
 | [Sakana Namazu](https://sakana.ai/namazu/)<br>([sakana-namazu](https://console.sakana.ai/models?model=sakana-namazu)) | **2026** | 262,144 | Sakana AI | self-owned |
+| [Syn](https://www.upstage.ai/news/introducing-upstage-japan)<br>([Syn](https://aws.amazon.com/marketplace/pp/prodview-if7zjxeioy5pg), [Syn Pro](https://aws.amazon.com/marketplace/pp/prodview-d7vt6ap2jhvfg)) | 2025 | 32,768 | KARAKURI, Upstage | AWS Marketplace (SageMaker) |
+| [tsuzumi](https://www.nttdata.com/global/ja/news/topics/2024/112000/)<br>([tsuzumi-7b](https://ai.azure.com/catalog/models/tsuzumi-7b), [tsuzumi 2](https://marketplace.microsoft.com/en-us/product/1681106214127.nttdata-tsuzumi-2-instruct-offer)) | 2025 | | NTT | Microsoft Foundry |
+| [PLaMo API](https://plamo.preferredai.jp/api) | 2024 | 32,768 | Preferred Networks | self-owned |
+| [LHTM-OPT](https://aws.amazon.com/marketplace/pp/prodview-nw62wpreit442) | 2024 | | alt Inc. | AWS Marketplace (SageMaker) |
+| [AI Novelist](https://ai-novel.com/account_api.php) | 2021 | 2,400 ~ 8,192 | Bit192 | self-owned |
 
 <a id="autoencoding"></a>
 ## Modèles encodeur


### PR DESCRIPTION
Closes #560

## 変更内容

### tsuzumi 2 の追加
「APIとして提供されているモデル」の tsuzumi の行に tsuzumi 2 を追記しました。同一シリーズのため行は分けず、Syn / Syn Pro と同じく括弧内にリンクを並べています。

- 公開年: 2024 → **2025**（[NTT 提供開始 2025-10-20](https://group.ntt/jp/newsrelease/2025/10/20/251020a.html)）。Azure での提供開始は [2026-05-20](https://www.nttdata.com/global/ja/news/topics/2026/052001/) ですが、公開年は開発元が提供を開始した年としました
- リンク先: [Microsoft Marketplace のオファー](https://marketplace.microsoft.com/en-us/product/1681106214127.nttdata-tsuzumi-2-instruct-offer)
- トークン数は空欄のまま: NTT データ製品ページ・NTT R&D・Microsoft Learn の Foundry モデル一覧・Marketplace のオファー説明・`tsuzumi on Azure MaaS ユーザーガイド` のいずれにもコンテキスト長の記載がありませんでした（Learn にあるのは tsuzumi-7b の 8,192 のみ）
- 参考: 30B パラメータ、1GPU 動作、フルスクラッチ開発

### API テーブルの並べ替え
公開年の降順（新しい順）に整理しました。同年内は既存の相対順を維持しています。

| 順 | モデル | 公開年 |
|---|---|---|
| 1 | Sakana Namazu | 2026 |
| 2 | Syn | 2025 |
| 3 | tsuzumi | 2025 |
| 4 | PLaMo API | 2024 |
| 5 | LHTM-OPT | 2024 |
| 6 | AIのべりすと | 2021 |

### ルールの明文化
`.claude/rules/table-formatting.md` に、API テーブルの行粒度（シリーズ単位で1行）・並び順・公開年の基準・トークン数不明時の扱いを追記しました。

README.md / en/README.md / fr/README.md の3ファイルを同一内容で更新しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)