### PR TITLE
llms.txt / llms-full.txt をビルド時に自動生成するように

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitepress'
 import footnote from 'markdown-it-footnote'
+import { generateLlmsTxt } from './llms'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -47,6 +48,9 @@ export default defineConfig({
     }
   },
   lastUpdated: true,
+  buildEnd(siteConfig) {
+    generateLlmsTxt(siteConfig)
+  },
   locales: {
     root: {
       label: '日本語',

--- a/.vitepress/llms.ts
+++ b/.vitepress/llms.ts
@@ -1,0 +1,63 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import type { SiteConfig } from 'vitepress'
+
+const SITE_URL = 'https://llm-jp.github.io/awesome-japanese-llm'
+
+const SOURCES = [
+  { src: 'README.md', out: 'llms-full.txt' },
+  { src: 'en/README.md', out: 'en/llms-full.txt' },
+  { src: 'fr/README.md', out: 'fr/llms-full.txt' },
+] as const
+
+const INDEX = `# 日本語LLMまとめ (Overview of Japanese LLMs)
+
+> 一般公開されている日本語LLM（日本語を中心に学習された大規模言語モデル）および日本語LLM評価ベンチマークの情報を、有志が継続的に収集・更新しているまとめ。モデルごとにアーキテクチャ、パラメータ数、学習データ、開発元、ライセンスを表形式で整理している。
+
+- GitHub リポジトリ: https://github.com/llm-jp/awesome-japanese-llm
+- This overview of Japanese LLMs is also available in English and French.
+
+## 全文 (Full content)
+
+- [日本語版 全文](${SITE_URL}/llms-full.txt): 日本語LLM・評価ベンチマーク一覧の全文（日本語）
+- [English full text](${SITE_URL}/en/llms-full.txt): Full overview of Japanese LLMs and benchmarks (English)
+- [Texte intégral en français](${SITE_URL}/fr/llms-full.txt): Aperçu complet des LLM japonais (français)
+
+## Web 版 (Web pages)
+
+- [日本語版](${SITE_URL}/)
+- [English version](${SITE_URL}/en/)
+- [Version française](${SITE_URL}/fr/)
+`
+
+function resolveIncludes(content: string, srcDir: string): string {
+  return content.replace(/<!--@include:\s*@\/(.+?)\s*-->/g, (_, path: string) =>
+    readFileSync(resolve(srcDir, path), 'utf-8')
+  )
+}
+
+function cleanForLlms(content: string): string {
+  return (
+    content
+      // Web 版への誘導ブロック（GitHub 閲覧時のみ表示）はプレーンテキストでは不要
+      .replace(/<div class="github-only">[\s\S]*?<\/div>\n?/g, '')
+      .replace(/^\[\[toc\]\]\n?/gm, '')
+      .replace(/^:::\s*details.*$\n?/gm, '')
+      .replace(/^:::\s*\w+\s+(.+)$/gm, '**$1**')
+      .replace(/^:::\s*$\n?/gm, '')
+      .replace(/<a id="[^"]*"><\/a>\s*/g, '')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim() + '\n'
+  )
+}
+
+export function generateLlmsTxt(siteConfig: SiteConfig): void {
+  const { srcDir, outDir } = siteConfig
+  writeFileSync(resolve(outDir, 'llms.txt'), INDEX)
+  for (const { src, out } of SOURCES) {
+    const raw = readFileSync(resolve(srcDir, src), 'utf-8')
+    const outPath = resolve(outDir, out)
+    mkdirSync(dirname(outPath), { recursive: true })
+    writeFileSync(outPath, cleanForLlms(resolveIncludes(raw, srcDir)))
+  }
+}


### PR DESCRIPTION
## 概要

[llms.txt](https://llmstxt.org/) の仕様に沿って、AI アシスタント・AI 検索エンジン向けのプレーンテキストをビルド時に自動生成するようにします。ChatGPT や Claude などが本リポジトリの内容を引用しやすくなり、AI 検索経由の流入増加を狙います。

## 変更内容

- `.vitepress/llms.ts` を新規追加: README から LLM 向けテキストを生成するモジュール
- `.vitepress/config.mts`: `buildEnd` フックで生成処理を呼び出し

デプロイ後、以下の URL で配信されます。

- `/awesome-japanese-llm/llms.txt` — 概要と各言語版全文へのリンクを載せた入口ファイル
- `/awesome-japanese-llm/llms-full.txt` — 日本語版全文
- `/awesome-japanese-llm/en/llms-full.txt` — 英語版全文
- `/awesome-japanese-llm/fr/llms-full.txt` — フランス語版全文

`public/` に静的ファイルを置く方式ではなくビルド時生成にしているため、README の更新に手動同期なしで追従します。

生成時のクリーニング処理:

- `<!--@include: @/parts/…-->` を展開（原論文セクションを本文に含める）
- GitHub 閲覧者向けの「Web 版をご利用ください」ブロックを除去
- `[[toc]]`・`:::` コンテナ記法を除去（warning のタイトル文は太字テキストとして保持）
- アンカータグ（`<a id="…"></a>`）を除去

## 動作確認

- `yarn docs:build` が成功し、`.vitepress/dist` 配下に 4 ファイルが生成されることを確認
- 生成された全ファイルに VitePress 固有記法（`@include` / `[[toc]]` / `:::` / `github-only`）が残っていないことを確認
- 表・リンク・脚注が保持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)