### PR TITLE
README の Web 版案内を GitHub アラート記法 (IMPORTANT) に変更

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitepress'
 import footnote from 'markdown-it-footnote'
-import { generateLlmsTxt } from './llms'
+import { generateLlmsTxt, GITHUB_ONLY_BLOCK } from './llms'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -48,6 +48,20 @@ export default defineConfig({
     }
   },
   lastUpdated: true,
+  vite: {
+    plugins: [
+      {
+        name: 'strip-github-only-blocks',
+        enforce: 'pre',
+        transform(code: string, id: string): string | undefined {
+          // GitHub 閲覧時のみ表示するブロック (<!-- github-only:start/end -->) を Web 版から除去する
+          if (id.endsWith('README.md')) {
+            return code.replace(GITHUB_ONLY_BLOCK, '')
+          }
+        },
+      },
+    ],
+  },
   buildEnd(siteConfig) {
     generateLlmsTxt(siteConfig)
   },

--- a/.vitepress/llms.ts
+++ b/.vitepress/llms.ts
@@ -30,6 +30,8 @@ const INDEX = `# 日本語LLMまとめ (Overview of Japanese LLMs)
 - [Version française](${SITE_URL}/fr/)
 `
 
+export const GITHUB_ONLY_BLOCK = /<!-- github-only:start -->[\s\S]*?<!-- github-only:end -->\n?/g
+
 function resolveIncludes(content: string, srcDir: string): string {
   return content.replace(/<!--@include:\s*@\/(.+?)\s*-->/g, (_, path: string) =>
     readFileSync(resolve(srcDir, path), 'utf-8')
@@ -40,7 +42,7 @@ function cleanForLlms(content: string): string {
   return (
     content
       // Web 版への誘導ブロック（GitHub 閲覧時のみ表示）はプレーンテキストでは不要
-      .replace(/<div class="github-only">[\s\S]*?<\/div>\n?/g, '')
+      .replace(GITHUB_ONLY_BLOCK, '')
       .replace(/^\[\[toc\]\]\n?/gm, '')
       .replace(/^:::\s*details.*$\n?/gm, '')
       .replace(/^:::\s*\w+\s+(.+)$/gm, '**$1**')

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -22,8 +22,3 @@ img {
 .vp-doc h5 {
   margin-top: 2rem;
 }
-
-/* GitHub専用要素をVitePressで非表示にする */
-.github-only {
-  display: none !important;
-}

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 
 <div class="github-only">
 
+> [!IMPORTANT]
 > **📖 より読みやすいWeb版をご利用ください**
-> 
+>
 > このREADMEの内容は、**[llm-jp.github.io/awesome-japanese-llm](https://llm-jp.github.io/awesome-japanese-llm)** でより見やすい形式でご覧いただけます。表の表示崩れやレイアウトの問題を防ぐため、Web版の閲覧を推奨いたします。
 
 </div>

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # 日本語LLMまとめ
 [ [**English**](./en/) | [**Français**](./fr/) | 日本語 ]
 
-<div class="github-only">
+<!-- github-only:start -->
 
 > [!IMPORTANT]
 > **📖 より読みやすいWeb版をご利用ください**
 >
 > このREADMEの内容は、**[llm-jp.github.io/awesome-japanese-llm](https://llm-jp.github.io/awesome-japanese-llm)** でより見やすい形式でご覧いただけます。表の表示崩れやレイアウトの問題を防ぐため、Web版の閲覧を推奨いたします。
 
-</div>
+<!-- github-only:end -->
 
 この記事は、一般公開されている日本語LLM（日本語を中心に学習されたLLM）および日本語LLM評価ベンチマークに関する情報をまとめたものです。情報は、有志により収集されており、その一部は論文や公開されているリソースなどから引用しています。
 

--- a/en/README.md
+++ b/en/README.md
@@ -3,6 +3,7 @@
 
 <div class="github-only">
 
+> [!IMPORTANT]
 > **📖 Please visit the more readable Web version**
 >
 > The content of this README is available in a more readable format at **[llm-jp.github.io/awesome-japanese-llm/en](https://llm-jp.github.io/awesome-japanese-llm/en/)**. We recommend viewing the Web version to avoid table display issues and layout problems.

--- a/en/README.md
+++ b/en/README.md
@@ -1,14 +1,14 @@
 # Overview of Japanese LLMs
 [ English | [**Français**](../fr/) | [**日本語**](../) ]
 
-<div class="github-only">
+<!-- github-only:start -->
 
 > [!IMPORTANT]
 > **📖 Please visit the more readable Web version**
 >
 > The content of this README is available in a more readable format at **[llm-jp.github.io/awesome-japanese-llm/en](https://llm-jp.github.io/awesome-japanese-llm/en/)**. We recommend viewing the Web version to avoid table display issues and layout problems.
 
-</div>
+<!-- github-only:end -->
 
 A list of publicly available LLMs trained with a focus on Japanese, along with their evaluation benchmarks, maintained by volunteers from various sources like academic papers and other public resources.
 

--- a/fr/README.md
+++ b/fr/README.md
@@ -1,14 +1,14 @@
 # Aperçu des grands modèles de langage (LLM) en japonais
 [ [**English**](../en/) | Français | [**日本語**](../) ]
 
-<div class="github-only">
+<!-- github-only:start -->
 
 > [!IMPORTANT]
 > **📖 Veuillez consulter la version Web plus lisible**
 >
 > Le contenu de ce README est disponible dans un format plus lisible sur **[llm-jp.github.io/awesome-japanese-llm/fr](https://llm-jp.github.io/awesome-japanese-llm/fr/)**. Nous recommandons de consulter la version Web pour éviter les problèmes d'affichage des tableaux et de mise en page.
 
-</div>
+<!-- github-only:end -->
 
 Voici une liste des LLMs disponibles au grand public, axés sur l'apprentissage du japonais, ainsi que leurs critères d'évaluation. Cette liste est maintenue par des bénévoles qui collectent des informations à partir de diverses sources telles que des articles académiques et d'autres ressources publiques.
 

--- a/fr/README.md
+++ b/fr/README.md
@@ -3,6 +3,7 @@
 
 <div class="github-only">
 
+> [!IMPORTANT]
 > **📖 Veuillez consulter la version Web plus lisible**
 >
 > Le contenu de ce README est disponible dans un format plus lisible sur **[llm-jp.github.io/awesome-japanese-llm/fr](https://llm-jp.github.io/awesome-japanese-llm/fr/)**. Nous recommandons de consulter la version Web pour éviter les problèmes d'affichage des tableaux et de mise en page.


### PR DESCRIPTION
## 概要

README 冒頭の「より読みやすいWeb版をご利用ください」ブロックを、GitHub のアラート記法（`> [!IMPORTANT]`、紫色の枠で表示されるもの）に変更します。

## 変更内容

当初 `<div class="github-only">` の中に `> [!IMPORTANT]` を書く方式を試しましたが、**GitHub は HTML ブロック内ではアラート記法を展開しない**（`[!IMPORTANT]` が文字のまま表示される）ことが分かったため、次の方式に変更しています。

- 3言語の README: `<div class="github-only">` ラッパーを廃止し、HTML コメントマーカー `<!-- github-only:start / end -->` で囲んだトップレベルの `> [!IMPORTANT]` ブロックに変更（コメントは GitHub 上では何も表示されません）
- `.vitepress/config.mts`: Vite の `transform` フック（`enforce: 'pre'`）でマーカー区間を Web 版ビルドから除去するプラグインを追加
- `.vitepress/llms.ts`: 除去用正規表現を `GITHUB_ONLY_BLOCK` として共通化し、llms-full.txt 生成でも同じマーカーを使用
- `.vitepress/theme/custom.css`: 不要になった `.github-only` ルールを削除

## 動作確認

- GitHub のレンダリング API（`Accept: application/vnd.github.html`）で、3言語すべての README に `markdown-alert-important` が出力されることを確認
- `yarn docs:build` 成功。Web 版の HTML（ja/en/fr）から案内ブロックが除去され、本文は保持されていることを確認
- `llms-full.txt` にも案内ブロックが含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)